### PR TITLE
Greedy cluster client

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@jupyterlab/codeeditor": "^0.19.1",
     "@jupyterlab/console": "^0.19.1",
     "@jupyterlab/coreutils": "^2.2.1",
+    "@jupyterlab/mainmenu": "^0.8.1",
     "@jupyterlab/notebook": "^0.19.1",
     "@jupyterlab/services": "^3.2.1",
     "@phosphor/coreutils": "^1.3.0",

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -8,6 +8,12 @@
       "type": "string",
       "title": "Default URL for the Dask Dashboard Webserver",
       "default": ""
+    },
+    "greedyClusterClient": {
+      "type": "boolean",
+      "title": "Greedy Cluster Client",
+      "description": "If set to true, every notebook and console will automatically have a dask client for the active cluster injected into the kernel under the name 'client'",
+      "default": false
     }
   },
   "type": "object"

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -9,9 +9,9 @@
       "title": "Default URL for the Dask Dashboard Webserver",
       "default": ""
     },
-    "greedyClusterClient": {
+    "autoStartClient": {
       "type": "boolean",
-      "title": "Greedy Cluster Client",
+      "title": "Auto-Start Client",
       "description": "If set to true, every notebook and console will automatically have a dask client for the active cluster injected into the kernel under the name 'client'",
       "default": false
     }

--- a/src/clusters.tsx
+++ b/src/clusters.tsx
@@ -112,6 +112,13 @@ export class DaskClusterManager extends Widget {
   }
 
   /**
+   * Set an active cluster by id.
+   */
+  setActiveCluster(id: string): void {
+    this._setActiveById(id);
+  }
+
+  /**
    * A signal that is emitted when an active cluster changes.
    */
   get activeClusterChanged(): ISignal<
@@ -126,6 +133,13 @@ export class DaskClusterManager extends Widget {
    */
   get clusters(): IClusterModel[] {
     return this._clusters;
+  }
+
+  /**
+   * Refresh the current list of clusters.
+   */
+  async refresh(): Promise<void> {
+    await this._updateClusterList();
   }
 
   /**
@@ -220,6 +234,17 @@ export class DaskClusterManager extends Widget {
     );
     const data = (await response.json()) as IClusterModel[];
     this._clusters = data;
+
+    // Check to see if the active cluster still exits.
+    // If it doesn't, or if there is no active cluster,
+    // select the first one.
+    const active = this._clusters.find(
+      c => c.id === (this._activeCluster && this._activeCluster.id)
+    );
+    if (!active) {
+      const id = (this._clusters[0] && this._clusters[0].id) || '';
+      this._setActiveById(id);
+    }
     this.update();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,14 +95,6 @@ function activate(
 ): void {
   const id = 'dask-dashboard-launcher';
 
-  // Whether a kernel should be used. Only evaluates to true
-  // if it is valid and in python.
-  const shouldUseKernel = (
-    kernel: Kernel.IKernelConnection | null | undefined
-  ) => {
-    return kernel && kernel.info && kernel.info.language_info.name === 'python';
-  };
-
   // Attempt to find a link to the dask dashboard
   // based on the currently active notebook/console
   const linkFinder = async () => {
@@ -113,7 +105,7 @@ function activate(
     );
     // Check to see if we found a kernel, and if its
     // language is python.
-    if (!shouldUseKernel(kernel)) {
+    if (!Private.shouldUseKernel(kernel)) {
       return '';
     }
     // If so, find the link if we can.
@@ -194,7 +186,7 @@ function activate(
     trackers.forEach(tracker => {
       tracker.forEach(widget => {
         const session = widget.session;
-        if (shouldUseKernel(session.kernel)) {
+        if (Private.shouldUseKernel(session.kernel)) {
           createClientForSession(session);
         }
       });
@@ -338,6 +330,18 @@ namespace Private {
    * A private counter for ids.
    */
   export let id = 0;
+
+  /**
+   * Whether a kernel should be used. Only evaluates to true
+   * if it is valid and in python.
+   */
+  export function shouldUseKernel(
+    kernel: Kernel.IKernelConnection | null | undefined
+  ): boolean {
+    return (
+      !!kernel && !!kernel.info && kernel.info.language_info.name === 'python'
+    );
+  }
 
   /**
    * Check a kernel for whether it has a default client dashboard address.

--- a/yarn.lock
+++ b/yarn.lock
@@ -153,6 +153,18 @@
     "@phosphor/signaling" "^1.2.2"
     "@phosphor/widgets" "^1.6.0"
 
+"@jupyterlab/mainmenu@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@jupyterlab/mainmenu/-/mainmenu-0.8.1.tgz#a691fbbf338498d83ec4e0f6e0dc4660291c25af"
+  dependencies:
+    "@jupyterlab/apputils" "^0.19.1"
+    "@jupyterlab/services" "^3.2.1"
+    "@phosphor/algorithm" "^1.1.2"
+    "@phosphor/commands" "^1.6.1"
+    "@phosphor/coreutils" "^1.3.0"
+    "@phosphor/disposable" "^1.1.2"
+    "@phosphor/widgets" "^1.6.0"
+
 "@jupyterlab/notebook@^0.19.1":
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@jupyterlab/notebook/-/notebook-0.19.1.tgz#3c6052a5e734b431802cf48d970a35668f76c6eb"


### PR DESCRIPTION
Work towards having all active notebooks and consoles get references to a client for the currently active Dask cluster. The current code injected into a kernel is 
```python
import dask; from dask.distributed import Client
dask.config.set({'scheduler-address': '${model.scheduler_address}'})
client = Client()
```