### PR TITLE
Add initial cluster parameters and instances

### DIFF
--- a/dask_labextension/clusterhandler.py
+++ b/dask_labextension/clusterhandler.py
@@ -17,12 +17,12 @@ class DaskClusterHandler(APIHandler):
     """
 
     @web.authenticated
-    def delete(self, cluster_id: str) -> None:
+    async def delete(self, cluster_id: str) -> None:
         """
         Delete a cluster by id.
         """
         try:  # to delete the cluster.
-            val = manager.close_cluster(cluster_id)
+            val = await manager.close_cluster(cluster_id)
             if val is None:
                 raise web.HTTPError(404, f"Dask cluster {cluster_id} not found")
 

--- a/dask_labextension/clusterhandler.py
+++ b/dask_labextension/clusterhandler.py
@@ -50,7 +50,7 @@ class DaskClusterHandler(APIHandler):
             self.finish(json.dumps(cluster_model))
 
     @web.authenticated
-    def put(self, cluster_id: str = "") -> None:
+    def put(self, cluster_id: str = "", configuration: str = "") -> None:
         """
         Create a new cluster with a given id. If no id is given, a random
         one is selected.
@@ -61,7 +61,8 @@ class DaskClusterHandler(APIHandler):
             )
 
         try:
-            cluster_model = manager.start_cluster(cluster_id)
+            configuration = json.loads(configuration)
+            cluster_model = manager.start_cluster(cluster_id, configuration)
             self.set_status(200)
             self.finish(json.dumps(cluster_model))
         except Exception as e:

--- a/dask_labextension/clusterhandler.py
+++ b/dask_labextension/clusterhandler.py
@@ -50,7 +50,7 @@ class DaskClusterHandler(APIHandler):
             self.finish(json.dumps(cluster_model))
 
     @web.authenticated
-    def put(self, cluster_id: str = "", configuration: str = "") -> None:
+    def put(self, cluster_id: str = "") -> None:
         """
         Create a new cluster with a given id. If no id is given, a random
         one is selected.
@@ -61,8 +61,7 @@ class DaskClusterHandler(APIHandler):
             )
 
         try:
-            configuration = json.loads(configuration)
-            cluster_model = manager.start_cluster(cluster_id, configuration)
+            cluster_model = manager.start_cluster(cluster_id)
             self.set_status(200)
             self.finish(json.dumps(cluster_model))
         except Exception as e:
@@ -76,11 +75,11 @@ class DaskClusterHandler(APIHandler):
         """
         new_model = json.loads(self.request.body)
         try:
-            if new_model["scaling"] == "adaptive":
+            if new_model.get("adapt") != None:
                 cluster_model = manager.adapt_cluster(
-                    cluster_id, new_model["minimum"], new_model["maximum"]
+                    cluster_id, new_model["adapt"]["minimum"], new_model["adapt"]["maximum"]
                 )
-            elif new_model["scaling"] == "static":
+            elif new_model.get("adapt") == None:
                 cluster_model = manager.scale_cluster(cluster_id, new_model["workers"])
             self.set_status(200)
             self.finish(json.dumps(cluster_model))

--- a/dask_labextension/clusterhandler.py
+++ b/dask_labextension/clusterhandler.py
@@ -50,7 +50,7 @@ class DaskClusterHandler(APIHandler):
             self.finish(json.dumps(cluster_model))
 
     @web.authenticated
-    def put(self, cluster_id: str = "") -> None:
+    async def put(self, cluster_id: str = "") -> None:
         """
         Create a new cluster with a given id. If no id is given, a random
         one is selected.
@@ -61,7 +61,7 @@ class DaskClusterHandler(APIHandler):
             )
 
         try:
-            cluster_model = manager.start_cluster(cluster_id)
+            cluster_model = await manager.start_cluster(cluster_id)
             self.set_status(200)
             self.finish(json.dumps(cluster_model))
         except Exception as e:

--- a/dask_labextension/labextension.yaml
+++ b/dask_labextension/labextension.yaml
@@ -7,3 +7,5 @@ labextension:
   default:
     workers: null
     adapt: null
+      # minimum: 0
+      # maximum: 10

--- a/dask_labextension/labextension.yaml
+++ b/dask_labextension/labextension.yaml
@@ -4,3 +4,8 @@ labextension:
     class: 'LocalCluster'
     args: []
     kwargs: {}
+  default:
+    workers: null
+    adapt: null
+      minimum: 0
+      maximum: 100

--- a/dask_labextension/labextension.yaml
+++ b/dask_labextension/labextension.yaml
@@ -6,6 +6,4 @@ labextension:
     kwargs: {}
   default:
     workers: null
-    adaptive: null
-      minimum: 0
-      maximum: 100
+    adapt: null

--- a/dask_labextension/labextension.yaml
+++ b/dask_labextension/labextension.yaml
@@ -10,3 +10,9 @@ labextension:
       # minimum: 0
       # maximum: 10
   initial: []
+    # - name: "My Big Cluster"
+    #   workers: 100
+    # - name: "Adaptive Cluster"
+    #   adapt:
+    #     minimum: 0
+    #     maximum: 50

--- a/dask_labextension/labextension.yaml
+++ b/dask_labextension/labextension.yaml
@@ -9,3 +9,4 @@ labextension:
     adapt: null
       # minimum: 0
       # maximum: 10
+  initial: []

--- a/dask_labextension/labextension.yaml
+++ b/dask_labextension/labextension.yaml
@@ -6,6 +6,6 @@ labextension:
     kwargs: {}
   default:
     workers: null
-    adapt: null
+    adaptive: null
       minimum: 0
       maximum: 100

--- a/dask_labextension/manager.py
+++ b/dask_labextension/manager.py
@@ -40,6 +40,7 @@ async def make_cluster(configuration: dict) -> Cluster:
 
     return cluster, adaptive
 
+
 def initial_cluster_models() -> List[ClusterModel]:
     models = dask.config.get('labextension.initial')
     return models
@@ -209,7 +210,6 @@ class DaskClusterManager:
 
     async def __aexit__(self, exc_type, exc, tb):
         await self.close()
-
 
 
 def make_cluster_model(

--- a/dask_labextension/manager.py
+++ b/dask_labextension/manager.py
@@ -32,8 +32,8 @@ def make_cluster(configuration: dict) -> Cluster:
     if configuration.get('workers') is not None:
         cluster.scale(configuration.get('workers'))
 
-    if configuration.get('adapt') is not None:
-        cluster.adapt(**configuration.get('adapt'))
+    if configuration.get('adaptive') is not None:
+        cluster.adapt(**configuration.get('adaptive'))
 
     return cluster
 
@@ -220,8 +220,10 @@ def make_cluster_model(
         cores=sum(ws.ncores for ws in cluster.scheduler.workers.values()),
     )
     if adaptive:
-        model["maximum"] = adaptive.maximum
-        model["minimum"] = adaptive.minimum
+        model['adaptive'] = {
+            'minimum': adaptive.minimum,
+            'maximum': adaptive.maximum,
+        }
 
     return model
 

--- a/dask_labextension/tests/test_basic.py
+++ b/dask_labextension/tests/test_basic.py
@@ -1,0 +1,23 @@
+import dask
+from dask_labextension.manager import DaskClusterManager
+from distributed.utils_test import gen_test
+
+
+@gen_test()
+async def test_core():
+    with dask.config.set({'labextension.defaults.kwargs': {'processes': False},  # for speed
+                          'labextension.initial': []}):
+        async with DaskClusterManager() as manager:
+
+            # add cluster
+            model = await manager.start_cluster(
+                    configuration={'adapt': {'minimum': 1, 'maximum': 3}}
+            )
+            assert model['adapt'] == {'minimum': 1, 'maximum': 3}
+
+            # close cluster
+            assert len(manager._clusters) == 1
+            model2 = await manager.close_cluster(model['id'])
+            assert not manager._clusters
+
+            await manager.close()

--- a/dask_labextension/tests/test_basic.py
+++ b/dask_labextension/tests/test_basic.py
@@ -5,19 +5,21 @@ from distributed.utils_test import gen_test
 
 @gen_test()
 async def test_core():
-    with dask.config.set({'labextension.defaults.kwargs': {'processes': False},  # for speed
-                          'labextension.initial': []}):
+    with dask.config.set({
+        'labextension.defaults.kwargs': {'processes': False},  # for speed
+        'labextension.initial': [],
+    }):
         async with DaskClusterManager() as manager:
 
             # add cluster
             model = await manager.start_cluster(
-                    configuration={'adapt': {'minimum': 1, 'maximum': 3}}
+                configuration={'adapt': {'minimum': 1, 'maximum': 3}}
             )
             assert model['adapt'] == {'minimum': 1, 'maximum': 3}
 
             # close cluster
             assert len(manager._clusters) == 1
-            model2 = await manager.close_cluster(model['id'])
+            await manager.close_cluster(model['id'])
             assert not manager._clusters
 
             await manager.close()

--- a/src/clusters.tsx
+++ b/src/clusters.tsx
@@ -336,15 +336,15 @@ function ClusterListingItem(props: IClusterListingItemProps) {
 
   let minimum: JSX.Element | null = null;
   let maximum: JSX.Element | null = null;
-  if (cluster.scaling === 'adaptive') {
+  if (cluster.adapt) {
     minimum = (
       <div className="dask-ClusterListingItem-stats">
-        Minimum Workers: {cluster.minimum}
+        Minimum Workers: {cluster.adapt.minimum}
       </div>
     );
     maximum = (
       <div className="dask-ClusterListingItem-stats">
-        Maximum Workers: {cluster.maximum}
+        Maximum Workers: {cluster.adapt.maximum}
       </div>
     );
   }
@@ -459,7 +459,7 @@ export interface IClusterListingItemProps {
 /**
  * An interface for a JSON-serializable representation of a cluster.
  */
-export interface IBaseClusterModel extends JSONObject {
+export interface IClusterModel extends JSONObject {
   /**
    * A unique string ID for the cluster.
    */
@@ -496,33 +496,8 @@ export interface IBaseClusterModel extends JSONObject {
   workers: number;
 
   /**
-   * The scaling type of the cluster model.
+   * If adaptive is enabled for the cluster, this contains an object
+   * with the minimum and maximum number of workers. Otherwise it is `null`.
    */
-  scaling: 'static' | 'adaptive';
+  adapt: null | { minimum: number; maximum: number };
 }
-
-export interface IStaticClusterModel extends IBaseClusterModel {
-  /**
-   * The scaling type of the cluster model.
-   */
-  scaling: 'static';
-}
-
-export interface IAdaptiveClusterModel extends IBaseClusterModel {
-  /**
-   * The scaling type of the cluster model.
-   */
-  scaling: 'adaptive';
-
-  /**
-   * The minimum number of workers.
-   */
-  minimum: number;
-
-  /**
-   * The maximum number of workers.
-   */
-  maximum: number;
-}
-
-export type IClusterModel = IStaticClusterModel | IAdaptiveClusterModel;

--- a/src/scaling.tsx
+++ b/src/scaling.tsx
@@ -1,10 +1,6 @@
 import { Dialog, showDialog } from '@jupyterlab/apputils';
 
-import {
-  IAdaptiveClusterModel,
-  IClusterModel,
-  IStaticClusterModel
-} from './clusters';
+import { IClusterModel } from './clusters';
 import * as React from 'react';
 
 /**
@@ -34,7 +30,15 @@ namespace ClusterScaling {
     /**
      * The proposed cluster model shown in the scaling.
      */
-    model: IUnionClusterModel;
+    model: IClusterModel;
+
+    /**
+     * Whether the proposed cluster is adaptive. We keep
+     * an extra flag here so that the transient adaptive
+     * min/max in the `model` is not overwritten while
+     * the user interacts with the dialog.
+     */
+    adaptive: boolean;
   }
 }
 
@@ -51,20 +55,23 @@ export class ClusterScaling extends React.Component<
    */
   constructor(props: ClusterScaling.IProps) {
     super(props);
-    let model: IUnionClusterModel;
+    let model: IClusterModel;
+    const adaptive = props.initialModel.adapt !== null;
     // If the initial model is static, enrich it
     // with placeholder values for minimum and maximum workers.
-    if (props.initialModel.scaling === 'static') {
+    if (!adaptive) {
       model = {
-        ...(props.initialModel as IStaticClusterModel),
-        minimum: props.initialModel.workers,
-        maximum: props.initialModel.workers
-      } as IUnionClusterModel;
+        ...props.initialModel,
+        adapt: {
+          minimum: props.initialModel.workers,
+          maximum: props.initialModel.workers
+        }
+      };
     } else {
-      model = props.initialModel as IUnionClusterModel;
+      model = props.initialModel;
     }
 
-    this.state = { model };
+    this.state = { adaptive, model };
   }
 
   /**
@@ -73,12 +80,11 @@ export class ClusterScaling extends React.Component<
    * be sent as the result of the dialog.
    */
   componentDidUpdate(): void {
-    let model: IUnionClusterModel = { ...this.state.model };
-    if (model.scaling === 'static') {
-      delete model['maximum'];
-      delete model['minimum'];
+    let model: IClusterModel = { ...this.state.model };
+    if (!this.state.adaptive) {
+      model.adapt = null;
     }
-    this.props.stateEscapeHatch(this.state.model as IClusterModel);
+    this.props.stateEscapeHatch(model);
   }
 
   /**
@@ -98,12 +104,9 @@ export class ClusterScaling extends React.Component<
    */
   onScalingChanged(event: React.ChangeEvent): void {
     const value = (event.target as HTMLInputElement).checked;
-    const scaling = value ? 'adaptive' : 'static';
     this.setState({
-      model: {
-        ...this.state.model,
-        scaling
-      } as IUnionClusterModel
+      model: this.state.model,
+      adaptive: value
     });
   }
 
@@ -114,12 +117,14 @@ export class ClusterScaling extends React.Component<
   onMinimumChanged(event: React.ChangeEvent): void {
     const value = parseInt((event.target as HTMLInputElement).value, 10);
     const minimum = Math.max(0, value);
-    const maximum = Math.max(this.state.model.maximum, minimum);
+    const maximum = Math.max(this.state.model.adapt!.maximum, minimum);
     this.setState({
       model: {
         ...this.state.model,
-        maximum,
-        minimum
+        adapt: {
+          maximum,
+          minimum
+        }
       }
     });
   }
@@ -131,12 +136,14 @@ export class ClusterScaling extends React.Component<
   onMaximumChanged(event: React.ChangeEvent): void {
     const value = parseInt((event.target as HTMLInputElement).value, 10);
     const maximum = Math.max(0, value);
-    const minimum = Math.min(this.state.model.minimum, maximum);
+    const minimum = Math.min(this.state.model.adapt!.minimum, maximum);
     this.setState({
       model: {
         ...this.state.model,
-        maximum,
-        minimum
+        adapt: {
+          maximum,
+          minimum
+        }
       }
     });
   }
@@ -146,7 +153,8 @@ export class ClusterScaling extends React.Component<
    */
   render() {
     const model = this.state.model;
-    const adaptive = model.scaling === 'adaptive';
+    const adapt = model.adapt!;
+    const adaptive = this.state.adaptive;
     const disabledClass = 'dask-mod-disabled';
     return (
       <div>
@@ -196,7 +204,7 @@ export class ClusterScaling extends React.Component<
               className="dask-ScalingInput"
               disabled={!adaptive}
               type="number"
-              value={(model as IAdaptiveClusterModel).minimum}
+              value={adapt.minimum}
               step="1"
               onChange={evt => {
                 this.onMinimumChanged(evt);
@@ -217,7 +225,7 @@ export class ClusterScaling extends React.Component<
               className="dask-ScalingInput"
               disabled={!adaptive}
               type="number"
-              value={(model as IAdaptiveClusterModel).maximum}
+              value={adapt.maximum}
               step="1"
               onChange={evt => {
                 this.onMaximumChanged(evt);
@@ -261,10 +269,3 @@ export function showScalingDialog(
     }
   });
 }
-
-/**
- * A module-private union type so that we always can refer
- * to the maximum/minimum values for the current cluster model
- * when we are in the dialog.
- */
-type IUnionClusterModel = IStaticClusterModel & IAdaptiveClusterModel;

--- a/src/scaling.tsx
+++ b/src/scaling.tsx
@@ -56,7 +56,7 @@ export class ClusterScaling extends React.Component<
   constructor(props: ClusterScaling.IProps) {
     super(props);
     let model: IClusterModel;
-    const adaptive = props.initialModel.adapt !== null;
+    const adaptive = !!props.initialModel.adapt;
     // If the initial model is static, enrich it
     // with placeholder values for minimum and maximum workers.
     if (!adaptive) {


### PR DESCRIPTION
This is joint work with @ian-r-rose 

This adds a few things:

-  The ability within the model to create workers and set adaptivity when a cluster is created
-  Configuration to trigger this by default
-  The ability to start clusters on startup
-  Additional asynchronous behavior on the server side

It currently depends on two PRs:

-  https://github.com/dask/distributed/pull/2437
-  https://github.com/dask/dask/pull/4324

To start reviewing I recommend looking at the changes to the default labextension.yaml file and then the tests (we have tests now!)