### PR TITLE
Friendlier empty panel

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -562,8 +562,6 @@ namespace Private {
 
   export function createInactivePanel(): HTMLElement {
     const panel = document.createElement('div');
-    const info = 'Cannot find dashboard';
-    panel.textContent = info;
     panel.className = 'dask-DaskDashboard-inactive';
     return panel;
   }

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -25,6 +25,8 @@ export class DaskDashboard extends MainAreaWidget<IFrame> {
   constructor() {
     super({ content: new IFrame() });
     this.content.url = '';
+    this._inactivePanel = Private.createInactivePanel();
+    this.active = false;
   }
 
   /**
@@ -49,6 +51,25 @@ export class DaskDashboard extends MainAreaWidget<IFrame> {
     this._updateUrl();
   }
 
+  /**
+   * Whether the dashboard is active. When inactive,
+   * it will show a placeholder panel.
+   */
+  get active(): boolean {
+    return this._active;
+  }
+  set active(value: boolean) {
+    if (value === this._active) {
+      return;
+    }
+    this._active = value;
+    if (this._active) {
+      this.content.node.appendChild(this._inactivePanel);
+    } else {
+      this.content.node.removeChild(this._inactivePanel);
+    }
+  }
+
   private _updateUrl(): void {
     if (!this.item || !this.dashboardUrl) {
       this.content.url = '';
@@ -59,6 +80,8 @@ export class DaskDashboard extends MainAreaWidget<IFrame> {
 
   private _item: IDashboardItem | null = null;
   private _dashboardUrl: string;
+  private _active: boolean;
+  private _inactivePanel: HTMLElement;
 }
 
 /**
@@ -525,5 +548,13 @@ namespace Private {
       };
       img.src = logoUrl;
     });
+  }
+
+  export function createInactivePanel(): HTMLElement {
+    const panel = document.createElement('div');
+    const info = 'Cannot find dashboard';
+    panel.textContent = info;
+    panel.className = 'dask-DaskDashboard-inactive';
+    return panel;
   }
 }

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -26,6 +26,7 @@ export class DaskDashboard extends MainAreaWidget<IFrame> {
     super({ content: new IFrame() });
     this.content.url = '';
     this._inactivePanel = Private.createInactivePanel();
+    this.content.node.appendChild(this._inactivePanel);
     this.active = false;
   }
 
@@ -64,9 +65,9 @@ export class DaskDashboard extends MainAreaWidget<IFrame> {
     }
     this._active = value;
     if (this._active) {
-      this.content.node.appendChild(this._inactivePanel);
+      this._inactivePanel.style.display = 'none';
     } else {
-      this.content.node.removeChild(this._inactivePanel);
+      this._inactivePanel.style.display = '';
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,19 +152,27 @@ function activate(
 
   app.shell.addToLeftArea(sidebar, { rank: 200 });
 
-  sidebar.dashboardLauncher.input.urlChanged.connect((sender, args) => {
+  const updateDashboards = () => {
+    const input = sidebar.dashboardLauncher.input;
     // Update the urls of open dashboards.
     tracker.forEach(widget => {
-      if (!args.isValid) {
+      if (!input.isValid) {
         widget.dashboardUrl = '';
+        widget.active = false;
         return;
       }
-      widget.dashboardUrl = args.newValue;
+      widget.dashboardUrl = input.url;
+      widget.active = true;
     });
+  };
+
+  sidebar.dashboardLauncher.input.urlChanged.connect((sender, args) => {
+    updateDashboards();
     // Save the current url to the state DB so it can be
     // reloaded on refresh.
     state.save(id, { url: args.newValue });
   });
+  updateDashboards();
 
   // Fetch the initial state of the settings.
   Promise.all([settings.load(PLUGIN_ID), state.fetch(id), app.restored]).then(

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,6 +197,7 @@ function activate(
     execute: args => {
       // Construct the url for the dashboard.
       const dashboardUrl = sidebar.dashboardLauncher.input.url;
+      const active = sidebar.dashboardLauncher.input.isValid;
       const dashboardItem = args as IDashboardItem;
 
       // If we already have a dashboard open to this url, activate it
@@ -213,6 +214,7 @@ function activate(
       const dashboard = new DaskDashboard();
       dashboard.dashboardUrl = dashboardUrl;
       dashboard.item = dashboardItem;
+      dashboard.active = active;
       dashboard.id = `dask-dashboard-${Private.id++}`;
       dashboard.title.label = `Dask ${dashboardItem.label}`;
       dashboard.title.icon = 'dask-DaskLogo';

--- a/style/index.css
+++ b/style/index.css
@@ -106,7 +106,26 @@
   left: 0;
   width: 100%;
   height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--jp-ui-font-color3);
+  font-size: var(--jp-ui-font-size3);
+  background-color: var(--jp-layout-color0);
   z-index: 10;
+}
+
+.dask-DaskDashboard-inactive:before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image: url(dask.svg);
+  background-repeat: no-repeat;
+  background-position: center;
+  opacity: 0.1;
 }
 
 /**

--- a/style/index.css
+++ b/style/index.css
@@ -98,6 +98,18 @@
 }
 
 /**
+ * Rules for the dashboard panels.
+ */
+.dask-DaskDashboard-inactive {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 10;
+}
+
+/**
  * Rules related to the cluster manager.
  */
 


### PR DESCRIPTION
This adds an overlay to the dashboard plots when there is no dashboard found. It prevents some ugly 404 errors from being shown to the user (at least for the most part).

![image](https://user-images.githubusercontent.com/5728311/50532413-dafb8180-0acd-11e9-98d7-eb8b48dfeb10.png)

cc @jhamman 