### PR TITLE
This function is now async in tornado 6.

### DIFF
--- a/dask_labextension/dashboardhandler.py
+++ b/dask_labextension/dashboardhandler.py
@@ -11,7 +11,11 @@ import inspect
 from tornado import web, httpclient, httputil, websocket, ioloop, version_info
 
 from notebook.base.handlers import IPythonHandler, utcnow
-from notebook.utils import maybe_future, url_path_join
+from notebook.utils import url_path_join
+try:
+    from notebook import maybe_future
+except ImportError:
+    from tornado.gen import maybe_future
 
 from .manager import manager
 

--- a/dask_labextension/dashboardhandler.py
+++ b/dask_labextension/dashboardhandler.py
@@ -11,7 +11,7 @@ import inspect
 from tornado import web, httpclient, httputil, websocket, ioloop, version_info
 
 from notebook.base.handlers import IPythonHandler, utcnow
-from notebook.utils import url_path_join
+from notebook.utils import maybe_future, url_path_join
 
 from .manager import manager
 
@@ -106,9 +106,9 @@ class WebSocketHandlerMixin(websocket.WebSocketHandler):
     async def get(self, *args, **kwargs):
         if self.request.headers.get("Upgrade", "").lower() != "websocket":
             return await self.http_get(*args, **kwargs)
-
-        # super get is not async
-        super().get(*args, **kwargs)
+        else:
+            result = super().get(*args, **kwargs)
+            await maybe_future(result)
 
 
 class DaskDashboardHandler(WebSocketHandlerMixin, IPythonHandler):


### PR DESCRIPTION
This is a side-port of jupyterhub/jupyter-server-proxy#119. It should fix dask/dask-examples#64.