### PR TITLE
Auto start client more reliably when a new widget is added by not waiting on an asynchronous fetch of kernel info.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -461,9 +461,7 @@ namespace Private {
   export function shouldUseKernel(
     kernel: Kernel.IKernelConnection | null | undefined
   ): boolean {
-    return (
-      !!kernel && !!kernel.info && kernel.info.language_info.name === 'python'
-    );
+    return !!kernel && kernel.name.toLowerCase().indexOf('python') !== -1;
   }
 
   /**


### PR DESCRIPTION
Small tweak to auto-starting client code to make it a bit less fussy about when kernel info comes in.