### PR TITLE
Better failures

### DIFF
--- a/src/clusters.tsx
+++ b/src/clusters.tsx
@@ -438,6 +438,12 @@ export class DaskClusterManager extends Widget {
       {},
       this._serverSettings
     );
+    if (response.status !== 200) {
+      const msg =
+        'Failed to list clusters: might the server extension not be installed/enabled?';
+      console.error(msg);
+      throw new Error(msg);
+    }
     const data = (await response.json()) as IClusterModel[];
     this._clusters = data;
 


### PR DESCRIPTION
This is an attempt to show more useful error messages when things go wrong. In particular, it tries to give error dialogs when clusters fail to start, stop, or scale, and it suggests that the server extension may not be installed correctly when not found.