### PR TITLE
If the user has manually set the proxy URL for the dashboard link, don't proxy again.

### DIFF
--- a/src/clusters.tsx
+++ b/src/clusters.tsx
@@ -59,7 +59,16 @@ export class DaskClusterManager extends Widget {
       if (!cluster) {
         return;
       }
-      options.setDashboardUrl(`dask/dashboard/${cluster.id}`);
+      if (cluster.dashboard_link.indexOf('/proxy') === 0) {
+        // If the dashboard link is already proxied using
+        // jupyter_server_proxy, don't proxy again. This
+        // can happen if the user has overridden the dashboard
+        // URL to the jupyter_server_proxy URL manually.
+        options.setDashboardUrl(cluster.dashboard_link);
+      } else {
+        // Otherwise, use the internal proxy URL.
+        options.setDashboardUrl(`dask/dashboard/${cluster.id}`);
+      }
 
       const old = this._activeCluster;
       if (old && old.id === cluster.id) {


### PR DESCRIPTION
Users frequently set `dashboard.link` in their dask config to that of the default `jupyter_server_proxy` URL. In that case, double proxying seems to make things not function properly.

This handles that case by checking if the dashboard link is *already* proxying, and simply using it if that is the case.