### PR TITLE
Support remote schedulers

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -9,11 +9,8 @@ conda create -q -n test-environment python=$PYTHON
 source activate test-environment
 conda install -q \
   pytest=3.7 \
+  dask=2.1 \
   notebook
 
-# Install unreleased versions of dask and distributed for now
-# in order to get a patched config system.
-pip install git+https://github.com/dask/dask.git@677d62a35bae0fb964472b604bc52ef91b46ea22
-pip install git+https://github.com/dask/distributed.git@538767b4977d1bd14679ae555b7705088a7e5a16
-
+pip install git+https://github.com/dask/distributed@c291175a975dfb9376724ececba10fcc9e2e43c0
 pip install -e .

--- a/dask_labextension/clusterhandler.py
+++ b/dask_labextension/clusterhandler.py
@@ -33,16 +33,16 @@ class DaskClusterHandler(APIHandler):
             raise web.HTTPError(500, str(e))
 
     @web.authenticated
-    def get(self, cluster_id: str = "") -> None:
+    async def get(self, cluster_id: str = "") -> None:
         """
         Get a cluster by id. If no id is given, lists known clusters.
         """
         if cluster_id == "":
-            cluster_list = manager.list_clusters()
+            cluster_list = await manager.list_clusters()
             self.set_status(200)
             self.finish(json.dumps(cluster_list))
         else:
-            cluster_model = manager.get_cluster(cluster_id)
+            cluster_model = await manager.get_cluster(cluster_id)
             if cluster_model is None:
                 raise web.HTTPError(404, f"Dask cluster {cluster_id} not found")
 
@@ -55,7 +55,7 @@ class DaskClusterHandler(APIHandler):
         Create a new cluster with a given id. If no id is given, a random
         one is selected.
         """
-        if manager.get_cluster(cluster_id):
+        if await manager.get_cluster(cluster_id):
             raise web.HTTPError(
                 403, f"A Dask cluster with ID {cluster_id} already exists!"
             )
@@ -68,7 +68,7 @@ class DaskClusterHandler(APIHandler):
             raise web.HTTPError(500, str(e))
 
     @web.authenticated
-    def patch(self, cluster_id):
+    async def patch(self, cluster_id):
         """
         Scale an existing cluster."
         Not yet implemented.
@@ -76,13 +76,13 @@ class DaskClusterHandler(APIHandler):
         new_model = json.loads(self.request.body)
         try:
             if new_model.get("adapt") != None:
-                cluster_model = manager.adapt_cluster(
+                cluster_model = await manager.adapt_cluster(
                     cluster_id,
                     new_model["adapt"]["minimum"],
                     new_model["adapt"]["maximum"],
                 )
             elif new_model.get("adapt") == None:
-                cluster_model = manager.scale_cluster(cluster_id, new_model["workers"])
+                cluster_model = await manager.scale_cluster(cluster_id, new_model["workers"])
             self.set_status(200)
             self.finish(json.dumps(cluster_model))
         except Exception as e:

--- a/dask_labextension/dashboardhandler.py
+++ b/dask_labextension/dashboardhandler.py
@@ -32,41 +32,41 @@ class DaskDashboardHandler(ProxyHandler):
         return await self.proxy(cluster_id, proxied_path)
 
     async def open(self, cluster_id, proxied_path):
-        host, port = self._get_parsed(cluster_id)
+        host, port = await self._get_parsed(cluster_id)
         return await super().proxy_open(host, port, proxied_path)
 
     # We have to duplicate all these for now, I've no idea why!
     # Figure out a way to not do that?
 
-    def post(self, cluster_id, proxied_path):
-        return self.proxy(cluster_id, proxied_path)
+    async def post(self, cluster_id, proxied_path):
+        return await self.proxy(cluster_id, proxied_path)
 
-    def put(self, cluster_id, proxied_path):
-        return self.proxy(cluster_id, proxied_path)
+    async def put(self, cluster_id, proxied_path):
+        return await self.proxy(cluster_id, proxied_path)
 
-    def delete(self, cluster_id, proxied_path):
-        return self.proxy(cluster_id, proxied_path)
+    async def delete(self, cluster_id, proxied_path):
+        return await self.proxy(cluster_id, proxied_path)
 
-    def head(self, cluster_id, proxied_path):
-        return self.proxy(cluster_id, proxied_path)
+    async def head(self, cluster_id, proxied_path):
+        return await self.proxy(cluster_id, proxied_path)
 
-    def patch(self, cluster_id, proxied_path):
-        return self.proxy(cluster_id, proxied_path)
+    async def patch(self, cluster_id, proxied_path):
+        return await self.proxy(cluster_id, proxied_path)
 
-    def options(self, cluster_id, proxied_path):
-        return self.proxy(cluster_id, proxied_path)
+    async def options(self, cluster_id, proxied_path):
+        return await self.proxy(cluster_id, proxied_path)
 
-    def proxy(self, cluster_id, proxied_path):
-        host, port = self._get_parsed(cluster_id)
+    async def proxy(self, cluster_id, proxied_path):
+        host, port = await self._get_parsed(cluster_id)
         return super().proxy(host, port, proxied_path)
 
-    def _get_parsed(self, cluster_id):
+    async def _get_parsed(self, cluster_id):
         """
         Given a cluster ID, get the hostname and port of its bokeh server.
         """
         # Get the cluster by ID. If it is not found,
         # raise an error.
-        cluster_model = manager.get_cluster(cluster_id)
+        cluster_model = await manager.get_cluster(cluster_id)
         if not cluster_model:
             raise web.HTTPError(404, f"Dask cluster {cluster_id} not found")
 

--- a/dask_labextension/tests/test_manager.py
+++ b/dask_labextension/tests/test_manager.py
@@ -38,8 +38,6 @@ async def test_start():
             )
             assert model['adapt'] == {'minimum': 1, 'maximum': 3}
 
-            await manager.close()
-
 @gen_test()
 async def test_close():
     with dask.config.set(config):

--- a/dask_labextension/tests/test_manager.py
+++ b/dask_labextension/tests/test_manager.py
@@ -7,20 +7,29 @@ from distributed.metrics import time
 
 from dask_labextension.manager import DaskClusterManager
 
+config = {
+    'labextension': {
+        "initial": [],
+        "default": {},
+        'factory': {
+            "module": "dask.distributed",
+            "class": "LocalCluster",
+            "kwargs": {"processes": False},
+            "args": []
+        }
+    }
+}
 
 @gen_test()
 async def test_start():
-    with dask.config.set({
-        'labextension.defaults.kwargs': {'processes': False},  # for speed
-        'labextension.initial': [],
-    }):
+    with dask.config.set(config):
         async with DaskClusterManager() as manager:
             # add cluster
             model = await manager.start_cluster()
             assert not model.get('adapt')
 
             # close cluster
-            assert len(manager.list_clusters()) == 1
+            assert len(await manager.list_clusters()) == 1
             await manager.close_cluster(model['id'])
 
             # add cluster with adaptive configuration
@@ -33,10 +42,7 @@ async def test_start():
 
 @gen_test()
 async def test_close():
-    with dask.config.set({
-        'labextension.defaults.kwargs': {'processes': False},  # for speed
-        'labextension.initial': [],
-    }):
+    with dask.config.set(config):
         async with DaskClusterManager() as manager:
             # start a cluster
             model = await manager.start_cluster()
@@ -46,79 +52,68 @@ async def test_close():
 
             # close the cluster
             await manager.close_cluster(model['id'])
-            assert not manager.list_clusters()
+            assert not await manager.list_clusters()
 
 @gen_test()
 async def test_get():
-    with dask.config.set({
-        'labextension.defaults.kwargs': {'processes': False},  # for speed
-        'labextension.initial': [],
-    }):
+    with dask.config.set(config):
         async with DaskClusterManager() as manager:
             # start a cluster
             model = await manager.start_cluster()
 
             # return None if a nonexistent cluster is requested
-            assert not manager.get_cluster('fake')
+            assert not await manager.get_cluster('fake')
 
             # get the cluster by id
-            assert model == manager.get_cluster(model['id'])
+            assert model == await manager.get_cluster(model['id'])
+
 
 @pytest.mark.filterwarnings('ignore')
 @gen_test()
 async def test_list():
-    with dask.config.set({
-        'labextension.defaults.kwargs': {'processes': False},  # for speed
-        'labextension.initial': [],
-    }):
+    with dask.config.set(config):
         async with DaskClusterManager() as manager:
             # start with an empty list
-            assert not manager.list_clusters()
+            assert not await manager.list_clusters()
             # start clusters
             model1 = await manager.start_cluster()
             model2 = await manager.start_cluster()
 
-            models = manager.list_clusters()
+            models = await manager.list_clusters()
             assert len(models) == 2
             assert model1 in models
             assert model2 in models
 
 @gen_test()
 async def test_scale():
-    with dask.config.set({
-        'labextension.defaults.kwargs': {'processes': False},  # for speed
-        'labextension.initial': [],
-    }):
+    with dask.config.set(config):
         async with DaskClusterManager() as manager:
             # add cluster with number of workers configuration
             model = await manager.start_cluster(configuration={'workers': 3})
             start = time()
             while model['workers'] != 3:
                 await sleep(0.01)
-                model = manager.get_cluster(model['id'])
+                model = await manager.get_cluster(model['id'])
                 assert time() < start + 10, model['workers']
 
             await sleep(0.2)  # let workers settle # TODO: remove need for this
 
             # rescale the cluster
-            model = manager.scale_cluster(model['id'], 6)
+            model = await manager.scale_cluster(model['id'], 6)
             start = time()
             while model['workers'] != 6:
                 await sleep(0.01)
-                model = manager.get_cluster(model['id'])
+                model = await manager.get_cluster(model['id'])
                 assert time() < start + 10, model['workers']
 
 @gen_test()
 async def test_adapt():
-    with dask.config.set({
-        'labextension.defaults.kwargs': {'processes': False},  # for speed
-        'labextension.initial': [],
-    }):
+    with dask.config.set(config):
         async with DaskClusterManager() as manager:
             # add a new cluster
             model = await manager.start_cluster()
             assert not model.get('adapt')
-            model = manager.adapt_cluster(model['id'], 0, 4)
+            model = await manager.adapt_cluster(model['id'], 0, 4)
             adapt = model.get('adapt')
             assert adapt
             assert adapt['minimum'] == 0
@@ -126,27 +121,25 @@ async def test_adapt():
 
 @gen_test()
 async def test_initial():
-    with dask.config.set({
-        'labextension.defaults.kwargs': {'processes': False},  # for speed
-        'labextension.initial': [{'name': 'foo'}],
-    }):
-        # Test asynchronous starting of clusters via a context
-        async with DaskClusterManager() as manager:
-            clusters = manager.list_clusters()
+    with dask.config.set(config):
+        with dask.config.set({"labextension.initial": [{"name": "foo"}]}):
+            # Test asynchronous starting of clusters via a context
+            async with DaskClusterManager() as manager:
+                clusters = await manager.list_clusters()
+                assert len(clusters) == 1
+                assert clusters[0]["name"] == 'foo'
+
+            # Test asynchronous starting of clusters outside of a context
+            manager = DaskClusterManager()
+            assert len(await manager.list_clusters()) == 0
+            await manager
+            clusters = await manager.list_clusters()
             assert len(clusters) == 1
             assert clusters[0]["name"] == 'foo'
+            await manager.close()
 
-        # Test asynchronous starting of clusters outside of a context
-        manager = DaskClusterManager()
-        assert len(manager.list_clusters()) == 0
-        await manager
-        clusters = manager.list_clusters()
-        assert len(clusters) == 1
-        assert clusters[0]["name"] == 'foo'
-        await manager.close()
-
-        manager = await DaskClusterManager()
-        clusters = manager.list_clusters()
-        assert len(clusters) == 1
-        assert clusters[0]["name"] == 'foo'
-        await manager.close()
+            manager = await DaskClusterManager()
+            clusters = await manager.list_clusters()
+            assert len(clusters) == 1
+            assert clusters[0]["name"] == 'foo'
+            await manager.close()


### PR DESCRIPTION
This PR includes two major changes:

1.  We now query the scheduler for its state, rather than assume that it is running locally
2.  We make a bunch of things async, in order to deal with the communication inherent in 1

Things seem to work well for me locally, except that the dashboard proxy seems unhappy.  

I'm testing with Dask's new SSHCluster, which is based on a new internal standard which everything should *hopefully* be based off of in the near future.

@ian-r-rose if you have time I could use your help with the proxy bits.  My attempt at this was the last commit.  I get errors like the following:

```python-traceback
/Users/mrocklin/miniconda/envs/dev2/lib/python3.7/asyncio/events.py:88: RuntimeWarning: coroutine 'ProxyHandler.proxy' was never awaited
```

My guess is that Jupyter-server-proxy doesn't support async functions for `ProxyHandler.proxy` subclasses.

For testing I'm using the following config file, which currently depends on a few not-yet-merged PRs in dask.distributed.

```yaml
labextension:
  factory:
     module: 'distributed.deploy.ssh2'
     class: 'SSHCluster'
     args: [["localhost", "localhost", "localhost", "localhost", "localhost", "localhost"]]
     kwargs:
       connect_kwargs:
         known_hosts: null
       scheduler_kwargs:
         port: 0
         dashboard_address: :0
       worker_kwargs:
         nthreads: 3
         memory_limit: 4 GiB
```