### PR TITLE
[REVIEW] Populate new plots using API request to cluster

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -119,10 +119,10 @@ export class DaskDashboardLauncher extends Widget {
     this._input.urlChanged.connect(this.updateLinks, this);
   }
 
-  protected async updateLinks() {
+  private async updateLinks(): Promise<void> {
     const result = await Private.getItems(
       this._input.url,
-      this._input._serverSettings
+      ServerConnection.makeSettings()
     );
     if (result) {
       let newItems: IDashboardItem[] = [];
@@ -372,13 +372,13 @@ export class URLInput extends Widget {
     });
   }
 
-  public _url = '';
-  public _serverSettings: ServerConnection.ISettings;
   private _urlChanged = new Signal<this, URLInput.IChangedArgs>(this);
+  private _url = '';
   private _isValid = false;
   private _input: HTMLInputElement;
   private _poll: Poll;
   private _isDisposed: boolean;
+  private _serverSettings: ServerConnection.ISettings;
 }
 
 /**

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -123,7 +123,7 @@ export class DaskDashboardLauncher extends Widget {
   private async updateLinks(): Promise<void> {
     const result = await Private.getItems(
       this._input.url,
-      ServerConnection.makeSettings()
+      this._serverSettings
     );
     if (result) {
       let newItems: IDashboardItem[] = [];

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -206,6 +206,8 @@ export class URLInput extends Widget {
     wrapper.node.appendChild(this._input);
     layout.addWidget(wrapper);
 
+    this._serverSettings = serverSettings;
+
     if (linkFinder) {
       const findButton = new ToolbarButton({
         iconClassName: 'dask-SearchIcon jp-Icon jp-Icon-16',
@@ -219,7 +221,6 @@ export class URLInput extends Widget {
       });
       layout.addWidget(findButton);
     }
-    this._serverSettings = serverSettings;
 
     this._startUrlCheckTimer();
   }

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -110,12 +110,13 @@ export class DaskDashboardLauncher extends Widget {
     super();
     let layout = (this.layout = new PanelLayout());
     this._dashboard = new Widget();
-    this._input = new URLInput(options.linkFinder);
+    this._launchItem = options.launchItem;
+    this._serverSettings = ServerConnection.makeSettings();
+    this._input = new URLInput(this._serverSettings, options.linkFinder);
     layout.addWidget(this._input);
     layout.addWidget(this._dashboard);
     this.addClass('dask-DaskDashboardLauncher');
     this._items = options.items || DaskDashboardLauncher.DEFAULT_ITEMS;
-    this._launchItem = options.launchItem;
     this._input.urlChanged.connect(this.updateLinks, this);
   }
 
@@ -181,6 +182,7 @@ export class DaskDashboardLauncher extends Widget {
   private _input: URLInput;
   private _launchItem: (item: IDashboardItem) => void;
   private _items: IDashboardItem[];
+  private _serverSettings: ServerConnection.ISettings;
 }
 
 /**
@@ -190,7 +192,10 @@ export class URLInput extends Widget {
   /**
    * Construct a new input element.
    */
-  constructor(linkFinder?: () => Promise<string>) {
+  constructor(
+    serverSettings: ServerConnection.ISettings,
+    linkFinder?: () => Promise<string>
+  ) {
     super();
     this.addClass('dask-URLInput');
     const layout = (this.layout = new PanelLayout());
@@ -200,8 +205,6 @@ export class URLInput extends Widget {
     this._input.placeholder = 'DASK DASHBOARD URL';
     wrapper.node.appendChild(this._input);
     layout.addWidget(wrapper);
-
-    this._serverSettings = ServerConnection.makeSettings();
 
     if (linkFinder) {
       const findButton = new ToolbarButton({
@@ -216,6 +219,7 @@ export class URLInput extends Widget {
       });
       layout.addWidget(findButton);
     }
+    this._serverSettings = serverSettings;
 
     this._startUrlCheckTimer();
   }

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -110,13 +110,13 @@ export class DaskDashboardLauncher extends Widget {
     super();
     let layout = (this.layout = new PanelLayout());
     this._dashboard = new Widget();
-    this._launchItem = options.launchItem;
     this._serverSettings = ServerConnection.makeSettings();
     this._input = new URLInput(this._serverSettings, options.linkFinder);
     layout.addWidget(this._input);
     layout.addWidget(this._dashboard);
     this.addClass('dask-DaskDashboardLauncher');
     this._items = options.items || DaskDashboardLauncher.DEFAULT_ITEMS;
+    this._launchItem = options.launchItem;
     this._input.urlChanged.connect(this.updateLinks, this);
   }
 

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -537,7 +537,7 @@ namespace Private {
   }
 
   /**
-   * Test whether a given URL hosts a dask dashboard.
+   * Return the json result of /individual-plots.json
    */
   export function getItems(
     url: string,

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -133,7 +133,6 @@ export class DaskDashboardLauncher extends Widget {
         newItems.push(item);
       }
       this._items = newItems;
-    } else {
     }
     this.update();
   }


### PR DESCRIPTION
Fixes #75 

Whenever the url changes, request the list of `individual-plots.json` and change `_items` to reflect it.