### PR TITLE
Dashboard fallback

### DIFF
--- a/style/index.css
+++ b/style/index.css
@@ -151,6 +151,12 @@
   margin: 0px;
 }
 
+.dask-DaskClusterManager button.jp-Button > span {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
 .dask-ClusterListing ul.dask-ClusterListing-list {
   list-style-type: none;
   padding: 0;


### PR DESCRIPTION
Fixes #94 , sort of. I think there is a limit to how good this fix can be -- we can't really make good API requests to the Bokeh server (including the `individual-plots.json` endpoint) from the browser due to CORS restrictions. This is also why we are jumping through some contortions to test whether the endpoint is even there. So this fix just falls back on the old default dashboard settings when a direct URL to a bokeh server is entered. Not ideal, but I wasn't able to find a way around it.

This is tricky to get right because, in addition to trying to work within CORS policies, we are trying to support at least three use-cases for the dashboard URL:
1. A raw bokeh server address (i.e., the case described in #94).
1. A bokeh server proxied using `jupyter-server-proxy` (e.g., `/proxy/8787`)
1. A bokeh server proxied by this extension's cluster manager.

All of which is to say, I'd appreciate another set of eyes on this to see if it works as expected :)