### PR TITLE
Support async scale methods

### DIFF
--- a/dask_labextension/clusterhandler.py
+++ b/dask_labextension/clusterhandler.py
@@ -68,7 +68,7 @@ class DaskClusterHandler(APIHandler):
             raise web.HTTPError(500, str(e))
 
     @web.authenticated
-    def patch(self, cluster_id):
+    async def patch(self, cluster_id):
         """
         Scale an existing cluster."
         Not yet implemented.
@@ -82,7 +82,7 @@ class DaskClusterHandler(APIHandler):
                     new_model["adapt"]["maximum"],
                 )
             elif new_model.get("adapt") == None:
-                cluster_model = manager.scale_cluster(cluster_id, new_model["workers"])
+                cluster_model = await manager.scale_cluster(cluster_id, new_model["workers"])
             self.set_status(200)
             self.finish(json.dumps(cluster_model))
         except Exception as e:

--- a/dask_labextension/tests/test_manager.py
+++ b/dask_labextension/tests/test_manager.py
@@ -100,7 +100,7 @@ async def test_scale():
             await sleep(0.2)  # let workers settle # TODO: remove need for this
 
             # rescale the cluster
-            model = manager.scale_cluster(model['id'], 6)
+            model = await manager.scale_cluster(model['id'], 6)
             start = time()
             while model['workers'] != 6:
                 await sleep(0.01)


### PR DESCRIPTION
This adds support for `cluster.scale` being an async method. For now
this support is optional, `cluster.scale` can be either an async or sync
method.

See https://github.com/dask/distributed/issues/3107.