### PR TITLE
Disable "+ NEW" button when cluster is starting

### DIFF
--- a/src/clusters.tsx
+++ b/src/clusters.tsx
@@ -1,4 +1,9 @@
-import { showErrorMessage, Toolbar, ToolbarButton, CommandToolbarButton } from '@jupyterlab/apputils';
+import {
+  showErrorMessage,
+  Toolbar,
+  ToolbarButton,
+  CommandToolbarButton
+} from '@jupyterlab/apputils';
 
 import { IChangedArgs, nbformat, Poll, URLExt } from '@jupyterlab/coreutils';
 
@@ -57,8 +62,8 @@ export class DaskClusterManager extends Widget {
     this._serverSettings = ServerConnection.makeSettings();
     this._injectClientCodeForCluster = options.injectClientCodeForCluster;
     this._getClientCodeForCluster = options.getClientCodeForCluster;
-    this.registry = options.registry
-    this.launchClusterId = options.launchClusterId
+    this.registry = options.registry;
+    this.launchClusterId = options.launchClusterId;
 
     // A function to set the active cluster.
     this._setActiveById = (id: string) => {
@@ -123,7 +128,7 @@ export class DaskClusterManager extends Widget {
       this.launchClusterId,
       new CommandToolbarButton({
         commands: this.registry,
-        id: this.launchClusterId,
+        id: this.launchClusterId
       })
     );
 
@@ -430,8 +435,8 @@ export class DaskClusterManager extends Widget {
    * Launch a new cluster on the server.
    */
   private async _launchCluster(): Promise<IClusterModel> {
-    this.status = 'starting'
-    this.registry.notifyCommandChanged(this.launchClusterId)
+    this.status = 'starting';
+    this.registry.notifyCommandChanged(this.launchClusterId);
     const response = await ServerConnection.makeRequest(
       `${this._serverSettings.baseUrl}dask/clusters`,
       { method: 'PUT' },
@@ -440,14 +445,14 @@ export class DaskClusterManager extends Widget {
     if (response.status !== 200) {
       const err = await response.json();
       void showErrorMessage('Cluster Start Error', err);
-      this.status = 'failed'
-      this.registry.notifyCommandChanged(this.launchClusterId)
+      this.status = 'failed';
+      this.registry.notifyCommandChanged(this.launchClusterId);
       throw err;
     }
     const model = (await response.json()) as IClusterModel;
     await this._updateClusterList();
-    this.status = 'ready'
-    this.registry.notifyCommandChanged(this.launchClusterId)
+    this.status = 'ready';
+    this.registry.notifyCommandChanged(this.launchClusterId);
     return model;
   }
 

--- a/src/clusters.tsx
+++ b/src/clusters.tsx
@@ -122,10 +122,10 @@ export class DaskClusterManager extends Widget {
 
     // Make a new cluster button for the toolbar.
     toolbar.addItem(
-      this.launchClusterId,
+      this._launchClusterId,
       new CommandToolbarButton({
-        commands: this.registry,
-        id: this.launchClusterId
+        commands: this._registry,
+        id: this._launchClusterId
       })
     );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -379,9 +379,9 @@ function activate(
     isEnabled: () => sidebar.clusterManager.isReady,
     caption: () => {
       if (sidebar.clusterManager.isReady) {
-        return 'Cluster starting...';
+        return 'Start New Dask Cluster';
       }
-      return 'Start New Dask Cluster';
+      return 'Cluster starting...';
     }
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -374,15 +374,15 @@ function activate(
   // Add a command to launch a new cluster.
   app.commands.addCommand(CommandIDs.launchCluster, {
     label: 'NEW',
-    execute:  () => sidebar.clusterManager.start(),
+    execute: () => sidebar.clusterManager.start(),
     iconClass: 'jp-AddIcon jp-Icon jp-Icon-16',
     isEnabled: () => sidebar.clusterManager.status != 'starting',
     caption: () => {
       if (sidebar.clusterManager.status == 'starting') {
-        return 'Cluster starting...'
+        return 'Cluster starting...';
       }
-      return 'Start New Dask Cluster'
-    },
+      return 'Start New Dask Cluster';
+    }
   });
 
   // Add a command to launch a new cluster.

--- a/src/index.ts
+++ b/src/index.ts
@@ -376,9 +376,9 @@ function activate(
     label: 'NEW',
     execute: () => sidebar.clusterManager.start(),
     iconClass: 'jp-AddIcon jp-Icon jp-Icon-16',
-    isEnabled: () => sidebar.clusterManager.status != 'starting',
+    isEnabled: () => sidebar.clusterManager.isReady,
     caption: () => {
-      if (sidebar.clusterManager.status == 'starting') {
+      if (sidebar.clusterManager.isReady) {
         return 'Cluster starting...';
       }
       return 'Start New Dask Cluster';

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,7 +149,9 @@ function activate(
     },
     linkFinder,
     clientCodeInjector,
-    clientCodeGetter: Private.getClientCode
+    clientCodeGetter: Private.getClientCode,
+    registry: app.commands,
+    launchClusterId: CommandIDs.launchCluster
   });
   sidebar.id = id;
   sidebar.title.iconClass = 'dask-DaskLogo jp-SideBar-tabIcon';
@@ -371,10 +373,16 @@ function activate(
 
   // Add a command to launch a new cluster.
   app.commands.addCommand(CommandIDs.launchCluster, {
-    label: 'Launch New Cluster',
-    execute: () => {
-      return sidebar.clusterManager.start();
-    }
+    label: 'NEW',
+    execute:  () => sidebar.clusterManager.start(),
+    iconClass: 'jp-AddIcon jp-Icon jp-Icon-16',
+    isEnabled: () => sidebar.clusterManager.status != 'starting',
+    caption: () => {
+      if (sidebar.clusterManager.status == 'starting') {
+        return 'Cluster starting...'
+      }
+      return 'Start New Dask Cluster'
+    },
   });
 
   // Add a command to launch a new cluster.

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -5,7 +5,6 @@ import { DaskDashboardLauncher, IDashboardItem } from './dashboard';
 
 import { DaskClusterManager, IClusterModel } from './clusters';
 
-
 /**
  * A widget for hosting Dask dashboard launchers.
  */
@@ -36,7 +35,7 @@ export class DaskSidebar extends Widget {
       launchClusterId: options.launchClusterId,
       setDashboardUrl,
       injectClientCodeForCluster,
-      getClientCodeForCluster,
+      getClientCodeForCluster
     });
     layout.addWidget(this._dashboard);
     layout.addWidget(this._clusters);

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1,8 +1,10 @@
 import { Widget, PanelLayout } from '@phosphor/widgets';
+import { CommandRegistry } from '@phosphor/commands';
 
 import { DaskDashboardLauncher, IDashboardItem } from './dashboard';
 
 import { DaskClusterManager, IClusterModel } from './clusters';
+
 
 /**
  * A widget for hosting Dask dashboard launchers.
@@ -30,9 +32,11 @@ export class DaskSidebar extends Widget {
     const getClientCodeForCluster = options.clientCodeGetter;
     // Add the cluster manager component.
     this._clusters = new DaskClusterManager({
+      registry: options.registry,
+      launchClusterId: options.launchClusterId,
       setDashboardUrl,
       injectClientCodeForCluster,
-      getClientCodeForCluster
+      getClientCodeForCluster,
     });
     layout.addWidget(this._dashboard);
     layout.addWidget(this._clusters);
@@ -64,6 +68,16 @@ export namespace DaskSidebar {
    * Options for the constructor.
    */
   export interface IOptions {
+    /**
+     * Registry of all commands
+     */
+    registry: CommandRegistry;
+
+    /**
+     * The launchCluster command ID.
+     */
+    launchClusterId: string;
+
     /**
      * A callback to launch a dashboard item.
      */


### PR DESCRIPTION
Closes #103 

After click on "+ NEW", button is disabled and tooltip text changes until cluster is launched:

![Screenshot from 2020-02-05 10-48-47](https://user-images.githubusercontent.com/4806877/73857789-6a14b600-4805-11ea-8a4d-784acd2f7700.png)

Note that to make this work, I switched from using `ToolbarButton` to `CommandToolbarButton` which allows for easier state updates. This was based on [this](https://gitter.im/jupyterlab/jupyterlab?at=5e399b1c433e1d403995d967) and [this](https://gitter.im/jupyterlab/jupyterlab?at=5e399cf9bfe65274eadcc9c3) comment in gitter.