### PR TITLE
Pin bokeh to less than version 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup_dict = dict(
         "Programming Language :: Python :: 3",
     ],
     install_requires=[
-        "bokeh",
+        "bokeh <2",
         "distributed>=1.24.1",
         "notebook>=4.3.1",
         "jupyter-server-proxy>=1.1.0",


### PR DESCRIPTION
Related to #121 

Pin bokeh to lower than v2 as current installs are broken. Fixes can be addressed later.