### PR TITLE
Add docs on enabling extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ following commands:
 ```bash
 pip install dask_labextension
 jupyter labextension install dask-labextension
+jupyter serverextension enable dask_labextension
 ```
 
 If you are running Notebook 5.2 or earlier, enable the server extension by running


### PR DESCRIPTION
I've noticed in a few situations that the extension needs to be manually enabled after installation. Even on Jupyter versions higher than the 5.2 mentioned in the docs

Therefore I've added the enable line to the install commands. As the command will do nothing if already enabled I see no harm.