### PR TITLE
Get dashboard link of client, not cluster

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -503,7 +503,7 @@ namespace Private {
   export function checkKernel(
     kernel: Kernel.IKernelConnection
   ): Promise<string> {
-    const code = `try:\n  from dask.distributed import default_client as _internal_jlab_default_client\n  display(_internal_jlab_default_client().cluster.dashboard_link)\nexcept:\n  pass`;
+    const code = `try:\n  from dask.distributed import default_client as _internal_jlab_default_client\n  display(_internal_jlab_default_client().dashboard_link)\nexcept:\n  pass`;
     const content: KernelMessage.IExecuteRequestMsg['content'] = {
       store_history: false,
       code


### PR DESCRIPTION
The dask.distributed.Client object already checks a local .cluster field
if it exists.  The approach in this commit is more general and works if
there isn't a local Cluster object.

Fixes https://github.com/dask/dask-labextension/issues/126