### PR TITLE
When a url doesn't work, remove from workspace

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -355,13 +355,22 @@ export class URLInput extends Widget {
           url,
           this._serverSettings
         );
-        // No change.
-        if (result === this._isValid) {
+        // No change - valid case
+        if (result && this._isValid) {
           return;
         }
         // Show an error if the connection died.
         if (!result && this._isValid) {
           console.warn(`The connection to dask dashboard ${url} has been lost`);
+        }
+        // No change - invalid case
+        if (!result && !this._isValid) {
+          // unset url
+          this._urlChanged.emit({
+            oldValue: url,
+            newValue: '',
+            isValid: result
+          });
         }
         // Connection died or started
         if (result !== this._isValid) {


### PR DESCRIPTION
Closes #152 

This is a pretty simple way around the issue. Basically on browser refresh if the dashboard url doesn't work, get rid of the url in the workspace.json. To test this out I created a cluster both programmatically and via the widget, then I shut them down and refreshed the browser tab. Without the browser tab refresh  you'll get 404s on a polling interval (4sec) but once you refresh you shouldn't have any polling anymore.