### PR TITLE
Check dashboard server side

### DIFF
--- a/dask_labextension/__init__.py
+++ b/dask_labextension/__init__.py
@@ -4,7 +4,7 @@ from notebook.utils import url_path_join
 
 from . import config
 from .clusterhandler import DaskClusterHandler
-from .dashboardhandler import DaskDashboardHandler
+from .dashboardhandler import DaskDashboardCheckHandler, DaskDashboardHandler
 
 
 from ._version import get_versions
@@ -32,9 +32,13 @@ def load_jupyter_server_extension(nb_server_app):
     get_dashboard_path = url_path_join(
         base_url, f"dask/dashboard/{cluster_id_regex}(?P<proxied_path>.+)"
     )
+    check_dashboard_path = url_path_join(
+        base_url, "dask/dashboard-check/(?P<url>.+)"
+    )
     handlers = [
         (get_cluster_path, DaskClusterHandler),
         (list_clusters_path, DaskClusterHandler),
         (get_dashboard_path, DaskDashboardHandler),
+        (check_dashboard_path, DaskDashboardCheckHandler),
     ]
     web_app.add_handlers(".*$", handlers)

--- a/dask_labextension/clusterhandler.py
+++ b/dask_labextension/clusterhandler.py
@@ -33,7 +33,7 @@ class DaskClusterHandler(APIHandler):
             raise web.HTTPError(500, str(e))
 
     @web.authenticated
-    def get(self, cluster_id: str = "") -> None:
+    async def get(self, cluster_id: str = "") -> None:
         """
         Get a cluster by id. If no id is given, lists known clusters.
         """

--- a/dask_labextension/dashboardhandler.py
+++ b/dask_labextension/dashboardhandler.py
@@ -43,6 +43,7 @@ class DaskDashboardCheckHandler(APIHandler):
             )
             # If we didn't get individual plots, it may not be a dask dashboard
             if individual_plots_response.code != 200:
+                self.log.warn(f"{url} does not seem to host a dask dashboard")
                 raise ValueError("Does not seem to host a dask dashboard")
             individual_plots = json.loads(individual_plots_response.body)
 

--- a/dask_labextension/dashboardhandler.py
+++ b/dask_labextension/dashboardhandler.py
@@ -37,13 +37,12 @@ class DaskDashboardCheckHandler(APIHandler):
             # Fetch the individual plots
             individual_plots_response = await client.fetch(
                 url_path_join(
-                    _normalize_dashboard_link(effective_url, self.request),
+                    _normalize_dashboard_link(effective_url or url, self.request),
                     "individual-plots.json"
                     )
             )
             # If we didn't get individual plots, it may not be a dask dashboard
             if individual_plots_response.code != 200:
-                self.log.warn(f"{url} does not seem to host a dask dashboard")
                 raise ValueError("Does not seem to host a dask dashboard")
             individual_plots = json.loads(individual_plots_response.body)
 
@@ -55,10 +54,12 @@ class DaskDashboardCheckHandler(APIHandler):
                 "plots": individual_plots,
             }))
         except:
+            self.log.warn(f"{url} does not seem to host a dask dashboard")
             self.set_status(200)
             self.finish(json.dumps({
                 "url": url,
                 "isActive": False,
+                "plots": {},
             }))
 
 

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -144,21 +144,15 @@ export class DaskDashboardLauncher extends Widget {
     this.addClass('dask-DaskDashboardLauncher');
     this._items = options.items || DaskDashboardLauncher.DEFAULT_ITEMS;
     this._launchItem = options.launchItem;
-    this._input.urlInfoChanged.connect(this.updateLinks, this);
+    this._input.urlInfoChanged.connect(this._updateLinks, this);
   }
 
-  private async updateLinks(
-    _: URLInput,
-    change: URLInput.IChangedArgs
-  ): Promise<void> {
+  private _updateLinks(_: URLInput, change: URLInput.IChangedArgs): void {
     if (!change.newValue.isActive) {
       this.update();
       return;
     }
-    const result = await Private.getDashboardPlots(
-      this._input.urlInfo.effectiveUrl || this._input.urlInfo.url,
-      this._serverSettings
-    );
+    const result = Private.getDashboardPlots(change.newValue);
     this._items = result;
     this.update();
   }
@@ -581,11 +575,7 @@ namespace Private {
   /**
    * Return the json result of /individual-plots.json
    */
-  export async function getDashboardPlots(
-    url: string,
-    settings: ServerConnection.ISettings
-  ): Promise<IDashboardItem[]> {
-    const info = await testDaskDashboard(url, settings);
+  export function getDashboardPlots(info: DashboardURLInfo): IDashboardItem[] {
     const plots: IDashboardItem[] = [];
     for (let key in info.plots) {
       const label = key.replace('Individual ', '');


### PR DESCRIPTION
This should resolve a number of long-running issues around user-provided dashboard URLs (that is to say, ones that are entered into the URL box, not those managed by the cluster manager). Previously we did a couple of things client-side:

1. Check to see if the url is valid
1. Load the list of individual plots from the bokeh server

This is for primarily historical reasons, as the server-side component of this extension did not always exist. It wound up causing a number of issues around CORS and mixed content. This moves the above checks to a new tornado handler on the server side, which have fewer such restrictions. It also allows us to more easily follow redirects.

Note: this still embeds the iframes directly from the bokeh server. We may want to also proxy those under the notebook server (as is done with the clusters launched by the labextension itself), but that can be in a follow-up, I think.

Fixes #158, fixes #137, probably fixes #32
