### PR TITLE
Update Readme: nodejs step - use conda-forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ These are available through a variety of sources.
 One source common to Python users is the conda package manager.
 
 ```bash
-conda install jupyterlab nodejs
+conda install jupyterlab
+conda install -c conda-forge nodejs
 ```
 
 This extension includes both a client-side JupyterLab extension and a server-side

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ distributed >= 1.24.1
 ## Installation
 
 To install the Dask JupyterLab extension you will need both JupyterLab,
-and [Node.js](https://nodejs.org/).
+and [Node.js](https://nodejs.org/), with at least version 12.
 These are available through a variety of sources.
 One source common to Python users is the conda package manager.
 


### PR DESCRIPTION
Hello,

I was trying to install the dask-extension to my jupyterlab but it seems that using `conda install nodejs` will install node 10 which is incompatible when we try to build the extension.

The solution seems to be installing nodejs from conda-forge instead (this [stackoverflow question might be helpful](https://stackoverflow.com/questions/62325068/cannot-install-latest-nodejs-using-conda-on-mac)).

Hopefully, this isn't just something that I hit because my conda environment got messed up somehow 🤔 