### PR TITLE
Add necessary metadata for editable labextension installs.

### DIFF
--- a/dask_labextension/__init__.py
+++ b/dask_labextension/__init__.py
@@ -13,6 +13,15 @@ __version__ = get_versions()["version"]
 del get_versions
 
 
+def _jupyter_labextension_paths():
+    return [
+        {
+            "src": "labextension",
+            "dest": "dask-labextension",
+        }
+    ]
+
+
 def _jupyter_server_extension_paths():
     return [{"module": "dask_labextension"}]
 


### PR DESCRIPTION
Fixes #177 .

This add some (poorly documented) metadata to the `__init__.py` which is needed for editable installs to work for the frontend code. @jacobtomlinson would you mind taking this for a spin to see if it fixes the issue for you?

I was able to get things working as expected with
```bash
pip install -e .   # editable install for the python code
jupyter labextension develop --overwrite    # editable install for the frontend code
```