### PR TITLE
Don't check the root bokeh URL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: stable
+    rev: 21.5b1
     hooks:
       - id: black
         language_version: python3

--- a/dask_labextension/dashboardhandler.py
+++ b/dask_labextension/dashboardhandler.py
@@ -29,42 +29,42 @@ class DaskDashboardCheckHandler(APIHandler):
         try:
             client = httpclient.AsyncHTTPClient()
 
-            # Check the user-provided url, following any redirects.
+            # Check the user-provided url
             url = _normalize_dashboard_link(parse.unquote(url), self.request)
-            try:
-                response = await client.fetch(url)
-                effective_url = (
-                    response.effective_url if response.effective_url != url else None
-                )
-            except httpclient.HTTPError:
-                # The page at /individual-plots.html might be available, even if `/` isn't.
-                effective_url = None
-
-            # Fetch the individual plots
             individual_plots_url = url_path_join(
-                _normalize_dashboard_link(effective_url or url, self.request),
+                url,
                 "individual-plots.json",
             )
-            self.log.info("Checking for individual plots at %s", individual_plots_url)
-            individual_plots_response = await client.fetch(individual_plots_url)
+            self.log.debug(f"Checking for individual plots at {individual_plots_url}")
+            response = await client.fetch(individual_plots_url)
+
             # If we didn't get individual plots, it may not be a dask dashboard
-            if individual_plots_response.code != 200:
+            if response.code != 200:
                 raise ValueError("Does not seem to host a dask dashboard")
-            individual_plots = json.loads(individual_plots_response.body)
+
+            # If the effective URL is different, strip off the individual-plots
+            # endpoint and include that as well.
+            effective_url = (
+                response.effective_url[: -len("individual-plots.json")]
+                if response.effective_url != individual_plots_url
+                else None
+            )
+
+            individual_plots = json.loads(response.body)
 
             self.set_status(200)
             self.finish(
                 json.dumps(
                     {
                         "url": url,
-                        "isActive": individual_plots_response.code == 200,
+                        "isActive": True,
                         "effectiveUrl": effective_url,
                         "plots": individual_plots,
                     }
                 )
             )
         except Exception:
-            self.log.exception(f"{url} does not seem to host a dask dashboard")
+            self.log.debug(f"{url} does not seem to host a dask dashboard")
             self.set_status(200)
             self.finish(
                 json.dumps(

--- a/dask_labextension/manager.py
+++ b/dask_labextension/manager.py
@@ -54,7 +54,7 @@ class DaskClusterManager:
     """
 
     def __init__(self) -> None:
-        """ Initialize the cluster manager """
+        """Initialize the cluster manager"""
         self._clusters: Dict[str, Cluster] = dict()
         self._adaptives: Dict[str, Adaptive] = dict()
         self._cluster_names: Dict[str, str] = dict()
@@ -213,7 +213,7 @@ class DaskClusterManager:
         return make_cluster_model(cluster_id, name, cluster, adaptive)
 
     async def close(self):
-        """ Close all clusters and cleanup """
+        """Close all clusters and cleanup"""
         for cluster_id in list(self._clusters):
             await self.close_cluster(cluster_id)
 


### PR DESCRIPTION
Fixes #185. Checking the root of the dask dashboard triggers a lot of bokeh document creation, which leaks memory. As a workaround, only sniff the known JSON endpoint.

This should be fairly safe, but I'd like to try this on a pangeo JupyterHub to ensure it doesn't break things.

Also fixes #180 while I'm at it