### PR TITLE
Improve button layout

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -142,7 +142,7 @@ export class DaskDashboardLauncher extends Widget {
     layout.addWidget(this._input);
     layout.addWidget(this._dashboard);
     this.addClass('dask-DaskDashboardLauncher');
-    this._items = options.items || DaskDashboardLauncher.DEFAULT_ITEMS;
+    this._items = options.items || [];
     this._launchItem = options.launchItem;
     this._input.urlInfoChanged.connect(this._updateLinks, this);
   }
@@ -435,32 +435,6 @@ export namespace DaskDashboardLauncher {
      */
     items?: IDashboardItem[];
   }
-
-  export const DEFAULT_ITEMS = [
-    { route: 'individual-task-stream', label: 'Task Stream' },
-    { route: 'individual-progress', label: 'Progress' },
-    { route: 'individual-workers', label: 'Workers' },
-    { route: 'individual-nbytes', label: 'Memory (worker)' },
-    { route: 'individual-cpu', label: 'CPU (workers)' },
-    { route: 'statics/individual-cluster-map.html', label: 'Cluster Map' },
-    { route: 'individual-graph', label: 'Graph' },
-    { route: 'individual-nprocessing', label: 'Processing Tasks' },
-    {
-      route: 'individual-compute-time-per-key',
-      label: 'Compute Time (operation)'
-    },
-    { route: 'individual-memory-by-key', label: 'Memory (operation)' },
-    { route: 'individual-profile', label: 'Profile' },
-    { route: 'individual-profile-server', label: 'Profile Server' },
-    { route: 'individual-bandwidth-workers', label: 'Bandwidth (workers)' },
-    { route: 'individual-bandwidth-types', label: 'Bandwidth (type)' },
-    {
-      route: 'individual-aggregate-time-per-action',
-      label: 'Compute/Transfer'
-    },
-    { route: 'individual-gpu-memory', label: 'GPU Memory' },
-    { route: 'individual-gpu-utilization', label: 'GPU Utilization' }
-  ];
 }
 
 /**

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -467,6 +467,13 @@ export namespace DaskDashboardLauncher {
  * A React component for a launcher button listing.
  */
 function DashboardListing(props: IDashboardListingProps) {
+  if (!props.isEnabled) {
+    return (
+      <div className="dask-DashboardListing-inactive">
+        Dashboard not connected
+      </div>
+    );
+  }
   const items = [...props.items].sort((e1, e2) =>
     e1.label <= e2.label ? -1 : 1
   );

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -444,7 +444,14 @@ function DashboardListing(props: IDashboardListingProps) {
   if (!props.isEnabled) {
     return (
       <div className="dask-DashboardListing-inactive">
-        Dashboard not connected
+        <span className="dask-DashboardListing-inactive-title">
+          Dashboard not connected
+        </span>
+        <span className="dask-DashboardListing-inactive-detail">
+          To connect, paste a dashboard URL in the box above, or create a new
+          Dask cluster with the cluster manager below. If you are still unable
+          to connect, check your network setup.
+        </span>
       </div>
     );
   }

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -467,7 +467,11 @@ export namespace DaskDashboardLauncher {
  * A React component for a launcher button listing.
  */
 function DashboardListing(props: IDashboardListingProps) {
-  let listing = props.items.map(item => {
+  const items = [...props.items].sort((e1, e2) =>
+    e1.label <= e2.label ? -1 : 1
+  );
+
+  const listing = items.map(item => {
     return (
       <li className="dask-DashboardListing-item" key={item.route}>
         <button

--- a/style/index.css
+++ b/style/index.css
@@ -1,5 +1,5 @@
 :root {
-  --dash-launch-button-height: 28px;
+  --dask-launch-button-height: 24px;
 }
 
 /**
@@ -17,6 +17,31 @@
  * Rules related to the dashboard launcher.
  */
 
+.dask-DashboardListing-inactive {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 600px;
+  color: var(--jp-ui-font-color3);
+  font-size: var(--jp-ui-font-size3);
+}
+
+.dask-DashboardListing-inactive:before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image: url(dask.svg);
+  background-repeat: no-repeat;
+  background-position: center;
+  opacity: 0.1;
+}
+
 .dask-DashboardListing-list {
   margin: 8px;
   padding: 0;
@@ -33,7 +58,8 @@
 
 .dask-DashboardListing-item button {
   font-size: var(--jp-ui-font-size0);
-  line-height: 24px;
+  border-radius: 2px;
+  line-height: 1em;
   padding: 0px 8px;
   width: 100%;
 }

--- a/style/index.css
+++ b/style/index.css
@@ -19,6 +19,7 @@
 
 .dask-DashboardListing-inactive {
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
   margin: 0;
@@ -26,7 +27,17 @@
   width: 100%;
   height: 600px;
   color: var(--jp-ui-font-color3);
+}
+
+.dask-DashboardListing-inactive-title {
   font-size: var(--jp-ui-font-size3);
+  padding: 24px;
+  text-align: center;
+}
+
+.dask-DashboardListing-inactive-detail {
+  font-size: var(--jp-ui-font-size4);
+  padding: 24px;
 }
 
 .dask-DashboardListing-inactive:before {
@@ -34,8 +45,8 @@
   position: absolute;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
+  width: 80%;
+  height: 80%;
   background-image: url(dask.svg);
   background-repeat: no-repeat;
   background-position: center;

--- a/style/index.css
+++ b/style/index.css
@@ -72,11 +72,6 @@
   text-transform: uppercase;
 }
 
-.dask-DashboardListing-item button:disabled.jp-mod-styled.jp-mod-accept {
-  background-color: var(--jp-layout-color3);
-  border: 1px solid var(--jp-layout-color3);
-}
-
 .dask-URLInput {
   padding: 8px;
   display: flex;

--- a/style/index.css
+++ b/style/index.css
@@ -18,17 +18,16 @@
  */
 
 .dask-DashboardListing-list {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: center;
   margin: 8px;
   padding: 0;
   list-style-type: none;
 }
 
 .dask-DashboardListing-item {
-  margin: 4px;
+  margin-top: 4px;
+  margin-bottom: 4px;
+  margin-left: 12px;
+  margin-right: 12px;
   white-space: nowrap;
 }
 
@@ -36,6 +35,7 @@
   font-size: var(--jp-ui-font-size0);
   line-height: 24px;
   padding: 0px 8px;
+  width: 100%;
 }
 
 .dask-DashboardListing-item button.jp-mod-styled.jp-mod-accept {


### PR DESCRIPTION
Some stylistic updates to the dashboard launcher buttons:

1. Remove default buttons, instead show a "Dashboard not connected" message if there is no valid dashboard (fixes #198).
2. Alphabetize the buttons so they are in a more predictable location (fixes #199 )
3. Changes the layout so buttons are one-per-line (I had changed it in prehistory to layout row-wise with overflow so we could fit more buttons in, but I think that made things too busy, and also made it tougher to find buttons)

Screenshots:
![image](https://user-images.githubusercontent.com/5728311/126310569-b9496994-2bad-4deb-ab47-513273f1ca43.png)

![image](https://user-images.githubusercontent.com/5728311/126310649-935cf613-419a-490c-bd6a-4baa3792a5aa.png)

