### PR TITLE
Remove 'Dask' from jupyter lab tab headings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -189,8 +189,8 @@ async function activate(
       }
 
       // Possibly update the name of the existing dashboard pane.
-      if (`Dask ${dashboard.label}` !== widget.title.label) {
-        widget.title.label = `Dask ${dashboard.label}`;
+      if (`${dashboard.label}` !== widget.title.label) {
+        widget.title.label = `${dashboard.label}`;
       }
 
       // If the dashboard server is inactive, mark it as such.
@@ -386,7 +386,7 @@ async function activate(
       dashboard.item = dashboardItem;
       dashboard.active = active;
       dashboard.id = `dask-dashboard-${Private.id++}`;
-      dashboard.title.label = `Dask ${dashboardItem.label}`;
+      dashboard.title.label = `${dashboardItem.label}`;
       dashboard.title.icon = 'dask-DaskLogo';
 
       labShell.add(dashboard, 'main');


### PR DESCRIPTION
Closes https://github.com/dask/dask-labextension/issues/201

It's easier to see which tab contains what plot if the headings don't all start with the same four letters (especially for small tabs with limited space).