### PR TITLE
Bump CI node version

### DIFF
--- a/.github/workflows/labextension.yml
+++ b/.github/workflows/labextension.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
+          node-version: '12.x'
       - name: Install Python
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
The browser-check seems to now have a dependency that needs it.

This shouldn't affect the requirements for users.