### PR TITLE
Fix restoration when not connected to a cluster

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -182,22 +182,17 @@ async function activate(
       // Identify the dashboard item associated with the widget
       const dashboard = dashboards.find(d => widget.item?.route === d.route);
 
-      // If the dashboard item doesn't exist in the new listing, close the pane.
-      if (!dashboard) {
-        widget.dispose();
+      // If the dashboard item doesn't exist in the new listing, or if the new
+      // url is inactive, mark the existing pane as such.
+      if (!dashboard || !input.urlInfo.isActive) {
+        widget.active = false;
+        widget.dashboardUrl = '';
         return;
       }
 
       // Possibly update the name of the existing dashboard pane.
       if (`${dashboard.label}` !== widget.title.label) {
         widget.title.label = `${dashboard.label}`;
-      }
-
-      // If the dashboard server is inactive, mark it as such.
-      if (!input.urlInfo.isActive) {
-        widget.dashboardUrl = '';
-        widget.active = false;
-        return;
       }
 
       widget.dashboardUrl = input.urlInfo.effectiveUrl || input.urlInfo.url;


### PR DESCRIPTION
Fixes #216. When the user connects to a cluster, there is this step of checking any existing dashboard panels to see if they are consistent with the available panels in the new cluster. The idea is, if the different versions of `distributed` have different panels available, or if the names for things have changed, we can update them. One of the checks just disposes of existing panels if they are not available.

This wound up being a bit too agressive upon refreshing the page when the user is *not* connected to anything. Since we removed the default dashboard panels in #200, this check for disposing of panels always trips, which, among other things, breaks the "initial layout" trick we use for the `dask-examples`.

This PR relaxes the disposal by just deactivating a panel if there is no match, rather than fully disposing of it, thus restoring the old behavior during an initial page load when no cluster is available.