### PR TITLE
Add option to hide the cluster manager

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -1,8 +1,8 @@
 {
   "jupyter.lab.setting-icon-class": "dask-DaskLogo",
-  "jupyter.lab.setting-icon-label": "Dask Dashboard",
-  "title": "Dask Dashboard",
-  "description": "Settings for the Dask Dashboard plugin.",
+  "jupyter.lab.setting-icon-label": "Dask",
+  "title": "Dask",
+  "description": "Settings for the Dask plugin.",
   "properties": {
     "defaultURL": {
       "type": "string",
@@ -13,6 +13,12 @@
       "type": "boolean",
       "title": "Auto-Start Client",
       "description": "If set to true, every notebook and console will automatically have a dask client for the active cluster injected into the kernel under the name 'client'",
+      "default": false
+    },
+    "hideClusterManager": {
+      "type": "boolean",
+      "title": "Hide Cluster Manager",
+      "description": "Some deployments don't want to or are unable to use the cluster manager feature. Toggle to hide it from the user interface (note: this does not disable the underlying functionality).",
       "default": false
     }
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -283,6 +283,10 @@ async function activate(
   // into the current session.
   let autoStartClient: boolean = false;
 
+  // Whether to hide the cluster manager for deployments that don't want to
+  // or are unable to use it.
+  let hideClusterManager: boolean = false;
+
   // Update the existing trackers and signals in light of a change to the
   // settings system. In particular, this reacts to a change in the setting
   // for auto-starting cluster client.
@@ -343,6 +347,11 @@ async function activate(
         // Determine whether to use the auto-starting client.
         autoStartClient = settings.get('autoStartClient').composite as boolean;
         updateTrackers();
+
+        //Determine whether to hide the cluster manager
+        hideClusterManager = settings.get('hideClusterManager')
+          .composite as boolean;
+        sidebar.clusterManager.setHidden(hideClusterManager);
       };
       onSettingsChanged();
       // React to a change in the settings.


### PR DESCRIPTION
Fixes #218 

This does not actually disable anything, it just hides the UI element from the sidebar. Users can distribute settings with `{'hideClusterManager': true}` to hide the cluster manager