### PR TITLE
[WIP] Add extra check for dashboards behind auth

### DIFF
--- a/.github/workflows/labextension.yml
+++ b/.github/workflows/labextension.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '16.x'
       - name: Install Python
         uses: actions/setup-python@v2
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.5b1
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -23,9 +23,10 @@
     },
     "browserDashboardCheck": {
       "type": "boolean",
-      "title": "Enable Test Dashboard with Fetch",
-      "description": "If set to true, the test dashboard will be validated with the a simple fetch request. This is useful for testing the dashboard when behind authentication.",
+      "title": "Determine whether to validate dashboards via browser check.",
+      "description": "If set to true, the test dashboard will be validated within the browser environment. This is useful for testing the dashboard when behind authentication.",
       "default": false
+    }
   },
   "type": "object"
 }

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -24,7 +24,7 @@
     "browserDashboardCheck": {
       "type": "boolean",
       "title": "Determine whether to validate dashboards via browser check.",
-      "description": "If set to true, the test dashboard will be validated within the browser environment. This is useful for testing the dashboard when behind authentication.",
+      "description": "If set to true, the test dashboard will be validated within the browser environment. This is useful for testing the dashboard when behind a browser-cookie based authentication.",
       "default": false
     }
   },

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -20,7 +20,12 @@
       "title": "Hide Cluster Manager",
       "description": "Some deployments don't want to or are unable to use the cluster manager feature. Toggle to hide it from the user interface (note: this does not disable the underlying functionality).",
       "default": false
-    }
+    },
+    "enableTestDashboardFetch": {
+      "type": "boolean",
+      "title": "Enable Test Dashboard with Fetch",
+      "description": "If set to true, the test dashboard will be validated with the a simple fetch request. This is useful for testing the dashboard when behind authentication.",
+      "default": false
   },
   "type": "object"
 }

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -21,7 +21,7 @@
       "description": "Some deployments don't want to or are unable to use the cluster manager feature. Toggle to hide it from the user interface (note: this does not disable the underlying functionality).",
       "default": false
     },
-    "enableTestDashboardFetch": {
+    "browserDashboardCheck": {
       "type": "boolean",
       "title": "Enable Test Dashboard with Fetch",
       "description": "If set to true, the test dashboard will be validated with the a simple fetch request. This is useful for testing the dashboard when behind authentication.",

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -576,7 +576,9 @@ namespace Private {
   ): Promise<DashboardURLInfo> {
     url = normalizeDashboardUrl(url, settings.baseUrl);
 
+    console.log(url)
     console.log(settings.baseUrl)
+    console.log(settings)
     // If Hostname matches the baseUrl, then we can fetch directly.
     // if (new URL(url).host === settings.baseUrl) {
     //   return fetch(
@@ -607,16 +609,16 @@ namespace Private {
     //     });
     // }
 
+    const test = await fetch(URLExt.join(url, 'individual-plots.json'))
+    console.log(await test.json())
+
     // If this is a url that we are proxying under the notebook server,
     // check for the individual charts directly.
     if (url.indexOf(settings.baseUrl) === 0) {
-      // return ServerConnection.makeRequest(
-      //   URLExt.join(url, 'individual-plots.json'),
-      //   {},
-      //   settings
-      // )
-      return fetch(
-        URLExt.join(url, 'individual-plots.json')
+      return ServerConnection.makeRequest(
+        URLExt.join(url, 'individual-plots.json'),
+        {},
+        settings
         )
         .then(async response => {
           if (response.status === 200) {
@@ -654,6 +656,7 @@ namespace Private {
       settings
     );
     const info = (await response.json()) as DashboardURLInfo;
+    console.log(info)
     return info;
   }
 

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -130,6 +130,7 @@ export class DaskDashboard extends MainAreaWidget<IFrame> {
  * A widget for hosting Dask dashboard launchers.
  */
 export class DaskDashboardLauncher extends Widget {
+  enableDashboardFetch: boolean;
   /**
    * Create a new Dask sidebar.
    */
@@ -138,6 +139,7 @@ export class DaskDashboardLauncher extends Widget {
     let layout = (this.layout = new PanelLayout());
     this._dashboard = new Widget();
     this._serverSettings = ServerConnection.makeSettings();
+    this.enableDashboardFetch = options.enableDashboardFetch;
     this._input = new URLInput(this._serverSettings, options.linkFinder);
     layout.addWidget(this._input);
     layout.addWidget(this._dashboard);
@@ -424,6 +426,10 @@ export namespace DaskDashboardLauncher {
    * Options for the constructor.
    */
   export interface IOptions {
+
+    /** Enable Test Dashboard with Fetch */
+    enableDashboardFetch: boolean;
+
     /**
      * A function that attempts to find a link to
      * a dask bokeh server in the current application
@@ -572,7 +578,8 @@ namespace Private {
    */
   export async function testDaskDashboard(
     url: string,
-    settings: ServerConnection.ISettings
+    settings: ServerConnection.ISettings,
+    enableDashboardFetch: boolean
   ): Promise<DashboardURLInfo> {
     url = normalizeDashboardUrl(url, settings.baseUrl);
 
@@ -609,7 +616,7 @@ namespace Private {
         });
     }
 
-    else if (url.includes("gateway")) {
+    else if (enableDashboardFetch) {
       return fetch(
         URLExt.join(url, 'individual-plots.json')
         )

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -301,9 +301,11 @@ export class URLInput extends Widget {
   /**
    * The in browser dashboard check for authenticated dashboards.
    */
+  get browserDashboardCheck(): boolean {
+    return this.browserDashboardCheck;
+  }
   set browserDashboardCheck(value: boolean) {
     this.browserDashboardCheck = value;
-    this.update();
   }
 
   /**

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -130,7 +130,6 @@ export class DaskDashboard extends MainAreaWidget<IFrame> {
  * A widget for hosting Dask dashboard launchers.
  */
 export class DaskDashboardLauncher extends Widget {
-  enableDashboardFetch: boolean;
   /**
    * Create a new Dask sidebar.
    */
@@ -139,7 +138,6 @@ export class DaskDashboardLauncher extends Widget {
     let layout = (this.layout = new PanelLayout());
     this._dashboard = new Widget();
     this._serverSettings = ServerConnection.makeSettings();
-    this.enableDashboardFetch = options.enableDashboardFetch;
     this._input = new URLInput(this._serverSettings, options.linkFinder);
     layout.addWidget(this._input);
     layout.addWidget(this._dashboard);
@@ -268,7 +266,7 @@ export class URLInput extends Widget {
     if (newValue === oldValue.url) {
       return;
     }
-    void Private.testDaskDashboard(newValue, this._serverSettings).then(
+    void Private.testDaskDashboard(newValue, this._serverSettings, this.browserDashboardCheck).then(
       result => {
         this._urlInfo = result;
         this._urlChanged.emit({ oldValue, newValue: result });
@@ -296,6 +294,11 @@ export class URLInput extends Widget {
    */
   get urlInfoChanged(): ISignal<this, URLInput.IChangedArgs> {
     return this._urlChanged;
+  }
+
+  set browserDashboardCheck(value: boolean) {
+    this.browserDashboardCheck = value;
+    this.update();
   }
 
   /**
@@ -426,9 +429,6 @@ export namespace DaskDashboardLauncher {
    * Options for the constructor.
    */
   export interface IOptions {
-
-    /** Enable Test Dashboard with Fetch */
-    enableDashboardFetch: boolean;
 
     /**
      * A function that attempts to find a link to
@@ -579,7 +579,7 @@ namespace Private {
   export async function testDaskDashboard(
     url: string,
     settings: ServerConnection.ISettings,
-    enableDashboardFetch: boolean
+    browserDashboardCheck: boolean = false
   ): Promise<DashboardURLInfo> {
     url = normalizeDashboardUrl(url, settings.baseUrl);
 
@@ -616,7 +616,7 @@ namespace Private {
         });
     }
 
-    else if (enableDashboardFetch) {
+    else if (browserDashboardCheck) {
       return fetch(
         URLExt.join(url, 'individual-plots.json')
         )

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -645,7 +645,6 @@ namespace Private {
     else if (url.includes("gateway")) {
       try {
         const response = await fetch(URLExt.join(url, 'individual-plots.json'))
-        console.log(await response.json())
         if (response.status === 200) {
           const plots = (await response.json()) as { [plot: string]: string };
           return {

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -269,7 +269,7 @@ export class URLInput extends Widget {
     void Private.testDaskDashboard(
       newValue,
       this._serverSettings,
-      this.browserDashboardCheck
+      this._browserDashboardCheck
     ).then(result => {
       this._urlInfo = result;
       this._urlChanged.emit({ oldValue, newValue: result });
@@ -302,10 +302,10 @@ export class URLInput extends Widget {
    * The in browser dashboard check for authenticated dashboards.
    */
   get browserDashboardCheck(): boolean {
-    return this.browserDashboardCheck;
+    return this._browserDashboardCheck;
   }
   set browserDashboardCheck(value: boolean) {
-    this.browserDashboardCheck = value;
+    this._browserDashboardCheck = value;
   }
 
   /**
@@ -405,6 +405,7 @@ export class URLInput extends Widget {
   private _urlInfo: DashboardURLInfo = { isActive: false, url: '', plots: {} };
   private _input: HTMLInputElement;
   private _poll: Poll;
+  private _browserDashboardCheck: boolean = false;
   private _serverSettings: ServerConnection.ISettings;
 }
 

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -266,19 +266,21 @@ export class URLInput extends Widget {
     if (newValue === oldValue.url) {
       return;
     }
-    void Private.testDaskDashboard(newValue, this._serverSettings, this.browserDashboardCheck).then(
-      result => {
-        this._urlInfo = result;
-        this._urlChanged.emit({ oldValue, newValue: result });
-        this._input.blur();
-        this.update();
-        if (!result) {
-          console.warn(
-            `${newValue} does not appear to host a valid Dask dashboard`
-          );
-        }
+    void Private.testDaskDashboard(
+      newValue,
+      this._serverSettings,
+      this.browserDashboardCheck
+    ).then(result => {
+      this._urlInfo = result;
+      this._urlChanged.emit({ oldValue, newValue: result });
+      this._input.blur();
+      this.update();
+      if (!result) {
+        console.warn(
+          `${newValue} does not appear to host a valid Dask dashboard`
+        );
       }
-    );
+    });
   }
 
   /**
@@ -296,6 +298,9 @@ export class URLInput extends Widget {
     return this._urlChanged;
   }
 
+  /**
+   * The in browser dashboard check for authenticated dashboards.
+   */
   set browserDashboardCheck(value: boolean) {
     this.browserDashboardCheck = value;
     this.update();
@@ -429,7 +434,6 @@ export namespace DaskDashboardLauncher {
    * Options for the constructor.
    */
   export interface IOptions {
-
     /**
      * A function that attempts to find a link to
      * a dask bokeh server in the current application
@@ -590,7 +594,7 @@ namespace Private {
         URLExt.join(url, 'individual-plots.json'),
         {},
         settings
-        )
+      )
         .then(async response => {
           if (response.status === 200) {
             const plots = (await response.json()) as { [plot: string]: string };
@@ -614,37 +618,32 @@ namespace Private {
             plots: {}
           };
         });
-    }
-
-    else if (browserDashboardCheck) {
-      return fetch(
-        URLExt.join(url, 'individual-plots.json')
-        )
-        .then (async response => {
+    } else if (browserDashboardCheck) {
+      return fetch(URLExt.join(url, 'individual-plots.json'))
+        .then(async response => {
           if (response.status === 200) {
             const plots = (await response.json()) as { [plot: string]: string };
-              return {
-                url,
-                isActive: true,
-                plots
-              };
-            } else {
-              return {
-                url,
-                isActive: false,
-                plots: {}
-              };
-            }
+            return {
+              url,
+              isActive: true,
+              plots
+            };
+          } else {
+            return {
+              url,
+              isActive: false,
+              plots: {}
+            };
           }
-        )
-        .catch((error) => {
+        })
+        .catch(error => {
           console.log('Fetch error: ', error);
           return {
             url,
             isActive: false,
             plots: {}
-        };
-      });
+          };
+        });
     }
 
     const response = await ServerConnection.makeRequest(

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -639,8 +639,7 @@ namespace Private {
             };
           }
         })
-        .catch(error => {
-          console.log('Fetch error: ', error);
+        .catch(() => {
           return {
             url,
             isActive: false,

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -578,43 +578,46 @@ namespace Private {
 
     console.log(settings.baseUrl)
     // If Hostname matches the baseUrl, then we can fetch directly.
-    if (new URL(url).host === settings.baseUrl) {
-      return fetch(
-        URLExt.join(url, 'individual-plots.json')
-        )
-        .then(async response => {
-          if (response.status === 200) {
-            const plots = (await response.json()) as { [plot: string]: string };
-            return {
-              url,
-              isActive: true,
-              plots
-            };
-          } else {
-            return {
-              url,
-              isActive: false,
-              plots: {}
-            };
-          }
-        })
-        .catch(() => {
-          return {
-            url,
-            isActive: false,
-            plots: {}
-          };
-        });
-    }
+    // if (new URL(url).host === settings.baseUrl) {
+    //   return fetch(
+    //     URLExt.join(url, 'individual-plots.json')
+    //     )
+    //     .then(async response => {
+    //       if (response.status === 200) {
+    //         const plots = (await response.json()) as { [plot: string]: string };
+    //         return {
+    //           url,
+    //           isActive: true,
+    //           plots
+    //         };
+    //       } else {
+    //         return {
+    //           url,
+    //           isActive: false,
+    //           plots: {}
+    //         };
+    //       }
+    //     })
+    //     .catch(() => {
+    //       return {
+    //         url,
+    //         isActive: false,
+    //         plots: {}
+    //       };
+    //     });
+    // }
 
     // If this is a url that we are proxying under the notebook server,
     // check for the individual charts directly.
     if (url.indexOf(settings.baseUrl) === 0) {
-      return ServerConnection.makeRequest(
-        URLExt.join(url, 'individual-plots.json'),
-        {},
-        settings
-      )
+      // return ServerConnection.makeRequest(
+      //   URLExt.join(url, 'individual-plots.json'),
+      //   {},
+      //   settings
+      // )
+      return fetch(
+        URLExt.join(url, 'individual-plots.json')
+        )
         .then(async response => {
           if (response.status === 200) {
             const plots = (await response.json()) as { [plot: string]: string };

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -576,13 +576,26 @@ namespace Private {
   ): Promise<DashboardURLInfo> {
     url = normalizeDashboardUrl(url, settings.baseUrl);
 
+    function isOauthProxy(url: string, settings: ServerConnection.ISettings) {
+      let proxyUrl = new URL(url);
+      if (proxyUrl.host === settings.baseUrl) {
+        return fetch(
+          URLExt.join(url, 'individual-plots.json'))
+      }
+      else {
+        return ServerConnection.makeRequest(
+          URLExt.join(url, 'individual-plots.json'),
+          {},
+          settings
+        )
+      }
+    }
+
     // If this is a url that we are proxying under the notebook server,
     // check for the individual charts directly.
     if (url.indexOf(settings.baseUrl) === 0) {
-      return ServerConnection.makeRequest(
-        URLExt.join(url, 'individual-plots.json'),
-        {},
-        settings
+      return isOauthProxy(
+        url, settings
       )
         .then(async response => {
           if (response.status === 200) {

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -374,7 +374,8 @@ export class URLInput extends Widget {
         }
         const result = await Private.testDaskDashboard(
           urlInfo.url,
-          this._serverSettings
+          this._serverSettings,
+          this._browserDashboardCheck
         );
         if (!result.isActive && urlInfo.isActive) {
           console.warn(

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -576,39 +576,6 @@ namespace Private {
   ): Promise<DashboardURLInfo> {
     url = normalizeDashboardUrl(url, settings.baseUrl);
 
-    console.log(url) // https://qhubstages2.qhub.dev/gateway/clusters/dev.d4a291e1f4214eef946bdcf02049169f/
-    console.log(settings.baseUrl) // https://qhubstages2.qhub.dev/user/test-user/
-    console.log(settings)
-    // If Hostname matches the baseUrl, then we can fetch directly.
-    // if (new URL(url).host === settings.baseUrl) {
-    //   return fetch(
-    //     URLExt.join(url, 'individual-plots.json')
-    //     )
-    //     .then(async response => {
-    //       if (response.status === 200) {
-    //         const plots = (await response.json()) as { [plot: string]: string };
-    //         return {
-    //           url,
-    //           isActive: true,
-    //           plots
-    //         };
-    //       } else {
-    //         return {
-    //           url,
-    //           isActive: false,
-    //           plots: {}
-    //         };
-    //       }
-    //     })
-    //     .catch(() => {
-    //       return {
-    //         url,
-    //         isActive: false,
-    //         plots: {}
-    //       };
-    //     });
-    // }
-
     // If this is a url that we are proxying under the notebook server,
     // check for the individual charts directly.
     if (url.indexOf(settings.baseUrl) === 0) {
@@ -643,25 +610,34 @@ namespace Private {
     }
 
     else if (url.includes("gateway")) {
-      try {
-        const response = await fetch(URLExt.join(url, 'individual-plots.json'))
-        if (response.status === 200) {
-          const plots = (await response.json()) as { [plot: string]: string };
-          return {
-            url,
-            isActive: true,
-            plots
-          };
-        } else {
+      return fetch(
+        URLExt.join(url, 'individual-plots.json')
+        )
+        .then (async response => {
+          if (response.status === 200) {
+            const plots = (await response.json()) as { [plot: string]: string };
+              return {
+                url,
+                isActive: true,
+                plots
+              };
+            } else {
+              return {
+                url,
+                isActive: false,
+                plots: {}
+              };
+            }
+          }
+        )
+        .catch((error) => {
+          console.log('Fetch error: ', error);
           return {
             url,
             isActive: false,
             plots: {}
-          };
-        }
-      } catch (error) {
-        console.log('Fetch error: ', error);
-      }
+        };
+      });
     }
 
     const response = await ServerConnection.makeRequest(
@@ -675,7 +651,6 @@ namespace Private {
       settings
     );
     const info = (await response.json()) as DashboardURLInfo;
-    console.log(info)
     return info;
   }
 

--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -576,8 +576,8 @@ namespace Private {
   ): Promise<DashboardURLInfo> {
     url = normalizeDashboardUrl(url, settings.baseUrl);
 
-    console.log(url)
-    console.log(settings.baseUrl)
+    console.log(url) // https://qhubstages2.qhub.dev/gateway/clusters/dev.d4a291e1f4214eef946bdcf02049169f/
+    console.log(settings.baseUrl) // https://qhubstages2.qhub.dev/user/test-user/
     console.log(settings)
     // If Hostname matches the baseUrl, then we can fetch directly.
     // if (new URL(url).host === settings.baseUrl) {
@@ -608,9 +608,6 @@ namespace Private {
     //       };
     //     });
     // }
-
-    const test = await fetch(URLExt.join(url, 'individual-plots.json'))
-    console.log(await test.json())
 
     // If this is a url that we are proxying under the notebook server,
     // check for the individual charts directly.
@@ -643,6 +640,29 @@ namespace Private {
             plots: {}
           };
         });
+    }
+
+    else if (url.includes("gateway")) {
+      try {
+        const response = await fetch(URLExt.join(url, 'individual-plots.json'))
+        console.log(await response.json())
+        if (response.status === 200) {
+          const plots = (await response.json()) as { [plot: string]: string };
+          return {
+            url,
+            isActive: true,
+            plots
+          };
+        } else {
+          return {
+            url,
+            isActive: false,
+            plots: {}
+          };
+        }
+      } catch (error) {
+        console.log('Fetch error: ', error);
+      }
     }
 
     const response = await ServerConnection.makeRequest(

--- a/src/index.ts
+++ b/src/index.ts
@@ -282,6 +282,10 @@ async function activate(
   // or are unable to use it.
   let hideClusterManager: boolean = false;
 
+  // Whether to test the Dask dashboard using a fetch request or to proceed
+  // with default behavior.
+  let enableTestDashboardFetch: boolean = false;
+
   // Update the existing trackers and signals in light of a change to the
   // settings system. In particular, this reacts to a change in the setting
   // for auto-starting cluster client.

--- a/src/index.ts
+++ b/src/index.ts
@@ -284,7 +284,7 @@ async function activate(
 
   // Whether to test the Dask dashboard using a fetch request or to proceed
   // with default behavior.
-  let enableTestDashboardFetch: boolean = false;
+  let browserDashboardCheck: boolean = false;
 
   // Update the existing trackers and signals in light of a change to the
   // settings system. In particular, this reacts to a change in the setting
@@ -346,6 +346,11 @@ async function activate(
         // Determine whether to use the auto-starting client.
         autoStartClient = settings.get('autoStartClient').composite as boolean;
         updateTrackers();
+
+        // Determine whether to validate dashboards via browser check.
+        browserDashboardCheck = settings.get('browserDashboardCheck')
+          .composite as boolean;
+        sidebar.dashboardLauncher.input.browserDashboardCheck = browserDashboardCheck;
 
         //Determine whether to hide the cluster manager
         hideClusterManager = settings.get('hideClusterManager')


### PR DESCRIPTION
closes #225 

This does not solve #190 completely but presents a second validation step using only a single `fetch` which enables the request to be performed in the same browser session.

There are some points here that I would like to point out:

- I am adding an extra condition here to check for `gateway` in the URL, but that's not ideal. I would like to have another opinion on which mechanic should be used here. I originally thought of passing an extra setting to the lab extension config to enable/disable this optional validation...
- My knowledge of TS/JS is very premature, so I just added this simple branch here. But I think the best approach should have been something like an `Interceptor` to verify the response and then move accordingly to that...


Well, this issue is fixed in our case with these changes, but I would love to know what I can do to improve this contribution and have such a feature added to main :smile: 