### PR TITLE
added new CSS class for DaskDashboard widget to have white background…

### DIFF
--- a/src/dashboard.tsx
+++ b/src/dashboard.tsx
@@ -58,6 +58,7 @@ export class DaskDashboard extends MainAreaWidget<IFrame> {
     });
     this._inactivePanel = Private.createInactivePanel();
     this.content.node.appendChild(this._inactivePanel);
+    this.addClass('dask-DaskDashboard-widget');
     this.update();
   }
 

--- a/style/index.css
+++ b/style/index.css
@@ -133,6 +133,10 @@
 /**
  * Rules for the dashboard panels.
  */
+.dask-DaskDashboard-widget {
+  background-color: white;
+}
+
 .dask-DaskDashboard-inactive {
   position: absolute;
   top: 0;


### PR DESCRIPTION
This fixes the issue of no visibility of widgets due to black background in JupyterLab Dark theme.
See: https://github.com/dask/dask-labextension/issues/242 and https://github.com/dask/distributed/issues/5200

changes:
- added new CSS class `dask-DaskDashboard-widget`
- iframe widgets in the constructor to use new CSS class

