### PR TITLE
Append any URL query args to dashboard URL paths

### DIFF
--- a/dask_labextension/dashboardhandler.py
+++ b/dask_labextension/dashboardhandler.py
@@ -195,4 +195,3 @@ def _normalize_dashboard_link(link, request):
         # If the default "status" dashboard is given, strip it.
         link = link[: -len("/status")]
     return link
-

--- a/dask_labextension/dashboardhandler.py
+++ b/dask_labextension/dashboardhandler.py
@@ -86,7 +86,8 @@ class DaskDashboardCheckHandler(APIHandler):
                 for name, plot_url in individual_plots.items():
                     individual_plots[name] = f"{plot_url}{query}"
                 url = f"{url}{query}"
-                effective_url = f"{url}{query}"
+                if effective_url:
+                    effective_url = f"{effective_url}{query}"
 
             self.set_status(200)
             self.finish(


### PR DESCRIPTION
If you enter `http://1.2.3.4/status?token=abc` as the dashboard address, the existing code will attempt to hit `http://1.2.3.4/status?token=abc/individual-plots.json`.

This makes it instead hit `http://1.2.3.4/individual-plots.json?token=abc`, and also append `?token=abc` to the paths of the individual plots.

With this change, it's possible to use dask-labextension with a dashboard that has token-based auth. (We're now doing this in Coiled, using an NGINX sidecar in front of the dashboard.)

<img width="821" alt="image" src="https://user-images.githubusercontent.com/46289310/219828638-8d336374-b93d-4839-a7dd-c9381a151492.png">
