### PR TITLE
Update styling for JupyterLab 4

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ import {
 
 import { CodeEditor } from '@jupyterlab/codeeditor';
 
+import { LabIcon } from '@jupyterlab/ui-components';
+
 import { ConsolePanel, IConsoleTracker } from '@jupyterlab/console';
 
 import { DocumentRegistry } from '@jupyterlab/docregistry';
@@ -43,6 +45,13 @@ import { DaskDashboard, IDashboardItem } from './dashboard';
 import { DaskSidebar } from './sidebar';
 
 import '../style/index.css';
+
+import DaskSvgStr from '../style/dask.svg';
+
+export const DaskIcon = new LabIcon({
+  name: 'dask:icon',
+  svgstr: DaskSvgStr
+});
 
 namespace CommandIDs {
   /**
@@ -175,7 +184,8 @@ async function activate(
     launchClusterId: CommandIDs.launchCluster
   });
   sidebar.id = id;
-  sidebar.title.iconClass = 'dask-DaskLogo jp-SideBar-tabIcon';
+  sidebar.title.icon = DaskIcon;
+  sidebar.title.iconClass = 'jp-SideBar-tabIcon';
   sidebar.title.caption = 'Dask';
 
   // An instance tracker which is used for state restoration.
@@ -431,7 +441,7 @@ async function activate(
       dashboard.active = active;
       dashboard.id = `dask-dashboard-${Private.id++}`;
       dashboard.title.label = `${dashboardItem.label}`;
-      dashboard.title.icon = 'dask-DaskLogo';
+      dashboard.title.icon = DaskIcon;
 
       labShell.add(dashboard, 'main', addOptions);
       void tracker.add(dashboard); // no need to wait on this

--- a/src/svg.d.ts
+++ b/src/svg.d.ts
@@ -1,17 +1,3 @@
-// Copyright 2022 IDRIS / jupyter
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 declare module '*.svg' {
   const image: string;
   export default image;

--- a/src/svg.d.ts
+++ b/src/svg.d.ts
@@ -1,0 +1,18 @@
+// Copyright 2022 IDRIS / jupyter
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+declare module '*.svg' {
+  const image: string;
+  export default image;
+}


### PR DESCRIPTION
Using the extension with JupyterLab 4 ends up with some malformed styling. Here is a screenshot

![dask-screenshot](https://github.com/dask/dask-labextension/assets/44365948/d58534b8-c752-4414-beca-4aa158d0ae33)

The default icon is overlapping Dask icon in the sidebar. The tab icons are broken too. This PR effectively fixes both of them. Screenshot after this patch

![dask-screenshot-fixed](https://github.com/dask/dask-labextension/assets/44365948/21e1308e-d14e-4887-a3db-79996831d805)

Closes #261 
