### PR TITLE
simplify the url pattern for cluster_id

### DIFF
--- a/dask_labextension/__init__.py
+++ b/dask_labextension/__init__.py
@@ -30,7 +30,7 @@ def load_jupyter_server_extension(nb_server_app):
     Args:
         nb_server_app (NotebookWebApplication): handle to the Notebook webserver instance.
     """
-    cluster_id_regex = r"(?P<cluster_id>\w+-\w+-\w+-\w+-\w+)"
+    cluster_id_regex = r"(?P<cluster_id>[^/]+)"
     web_app = nb_server_app.web_app
     base_url = web_app.settings["base_url"]
     get_cluster_path = url_path_join(base_url, "dask/clusters/" + cluster_id_regex)


### PR DESCRIPTION
rather than requiring it to look like a UUID, accept any single URL path component

results in clearer error: "no such cluster" instead of generic 404 with no matching router and allows for alternate id patterns (e.g. Gateway clusters, which already have ids)