### PR TITLE
fix: Stop lumino polling for clusters when connection is lost

### DIFF
--- a/src/clusters.tsx
+++ b/src/clusters.tsx
@@ -146,7 +146,7 @@ export class DaskClusterManager extends Widget {
         await this._updateClusterList();
       },
       frequency: { interval: REFRESH_INTERVAL, backoff: true, max: 60 * 1000 },
-      standby: 'when-hidden'
+      standby: options.refreshStandby || 'when-hidden'
     });
   }
 
@@ -614,6 +614,11 @@ export namespace DaskClusterManager {
      * A callback to get client code for a cluster.
      */
     getClientCodeForCluster: (model: IClusterModel) => string;
+
+    /**
+     * When the model stops polling the API. Defaults to `when-hidden`.
+     */
+    refreshStandby?: Poll.Standby | (() => boolean | Poll.Standby);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,8 @@ import {
   ILabShell,
   ILayoutRestorer,
   JupyterFrontEnd,
-  JupyterFrontEndPlugin
+  JupyterFrontEndPlugin,
+  JupyterLab
 } from '@jupyterlab/application';
 
 import {
@@ -120,6 +121,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     ISettingRegistry,
     IStateDB
   ],
+  optional: [JupyterLab.IInfo],
   autoStart: true
 };
 
@@ -140,7 +142,8 @@ async function activate(
   mainMenu: IMainMenu,
   notebookTracker: INotebookTracker,
   settingRegistry: ISettingRegistry,
-  state: IStateDB
+  state: IStateDB,
+  info: JupyterLab.IInfo | null
 ): Promise<void> {
   const id = 'dask-dashboard-launcher';
 
@@ -183,7 +186,13 @@ async function activate(
     clientCodeInjector,
     clientCodeGetter: Private.getClientCode,
     registry: app.commands,
-    launchClusterId: CommandIDs.launchCluster
+    launchClusterId: CommandIDs.launchCluster,
+    refreshStandby: () => {
+      if (info) {
+        return !info.isConnected || 'when-hidden';
+      }
+      return 'when-hidden';
+    }
   });
   sidebar.id = id;
   sidebar.title.icon = DaskIcon;

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1,4 +1,5 @@
 import { Widget, PanelLayout } from '@lumino/widgets';
+import { Poll } from '@lumino/polling';
 import { CommandRegistry } from '@lumino/commands';
 
 import { DaskDashboardLauncher, IDashboardItem } from './dashboard';
@@ -98,5 +99,10 @@ export namespace DaskSidebar {
      * A function that gets client-connection code for a given cluster.
      */
     clientCodeGetter: (model: IClusterModel) => string;
+
+    /**
+     * When the model stops polling the API. Defaults to `when-hidden`.
+     */
+    refreshStandby?: Poll.Standby | (() => boolean | Poll.Standby);
   }
 }


### PR DESCRIPTION
* Currently lumino polls for available clusters with a given frequency. However, when the server terminates, the polling does not stop as long as the browser tab is active. This is an issue in JupyterHub deployments where terminated servers keep making requests to hub when the browser tabs are kept open. This is undesirable as hub still needs to respond to these requests although they end up with 424.
* More background on [JupyterLab #17567](https://github.com/jupyterlab/jupyterlab/pull/17567)

@jacobtomlinson @ian-r-rose  Could you please take a look at it? Also should we drop support for Python 3.8 and add support for 3.12 and 3.13 which will be inline with JupyterLab? Cheers!!