### PR TITLE
Drop unsupported Python versions and update action workflows

### DIFF
--- a/.github/workflows/labextension.yml
+++ b/.github/workflows/labextension.yml
@@ -12,12 +12,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.11']
+        python-version: ['3.9', '3.13']
         jupyterlab-version: ['4']
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Base Setup
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Install dependencies

--- a/.github/workflows/labextension.yml
+++ b/.github/workflows/labextension.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.13']
+        python-version: ['3.10', '3.13']
         jupyterlab-version: ['4']
 
     steps:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-      - uses: pre-commit/action@v2.0.0
+      - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - uses: pre-commit/action@v2.0.0

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.13']
+        python-version: ['3.10', '3.13']
 
     steps:
       - name: Checkout

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -13,24 +13,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.11']
+        python-version: ['3.9', '3.13']
 
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          miniconda-version: latest
-          activate-environment: test
-          python-version: ${{ matrix.python-version }}
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Install
         shell: bash -l {0}
-        run: |
-          python -m pip install '.[test]'
+        run: python -m pip install '.[test]'
 
       - name: Run Tests
         shell: bash -l {0}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.3.0
+    rev: 25.1.0
     hooks:
       - id: black
         language_version: python3
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.2.0
     hooks:
       - id: flake8
         language_version: python3

--- a/dask_labextension/dashboardhandler.py
+++ b/dask_labextension/dashboardhandler.py
@@ -3,6 +3,7 @@ A Dashboard handler for the Dask labextension.
 This proxies the bokeh server http and ws requests through the notebook
 server, preventing CORS issues.
 """
+
 import json
 from inspect import isawaitable
 from urllib import parse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,15 +6,16 @@ build-backend = "hatchling.build"
 name = "dask_labextension"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Framework :: Jupyter",
 ]
 dependencies = [
@@ -77,10 +78,11 @@ ignore = ["W002"]
 [tool.black]
 # target-version should be all supported versions
 target_version = [
-    "py38",
     "py39",
     "py310",
     "py311",
+    "py312",
+    "py313",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,11 @@ build-backend = "hatchling.build"
 name = "dask_labextension"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ ignore = ["W002"]
 [tool.black]
 # target-version should be all supported versions
 target_version = [
-    "py39",
     "py310",
     "py311",
     "py312",


### PR DESCRIPTION
* Unsupported Python versions have been dropped from `pyproject.toml` and minimum supported Python has been bumped to `3.10` in line [dask](https://github.com/dask/dask/blob/87a177d866521a573f7a147cbee4dec7235f88f4/pyproject.toml#L29)
* CI workflows have been updated and action versions have been bumped
* Linters versions have been bumped in the pre-commit config